### PR TITLE
Pass params through to workflow execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 JavaScript-native distributed workflows that can be orchestrated by any backend.
 
 ```ts
-import { createWorkflow, RetryableError } from "yieldstar";
+import { workflow, RetryableError } from "yieldstar";
 
-const workflow = createWorkflow(async function* (step) {
+const myWorkflow = workflow(async function* (step, event, logger) {
+  const { params } = event; // Access workflow parameters
+
   let num = yield* step.run(() => {
     return fetch("https://randomnumber.com")
       .then((res) => res.json())
@@ -21,6 +23,33 @@ const workflow = createWorkflow(async function* (step) {
   });
 
   return num;
+});
+```
+
+## Passing Parameters to Workflows
+
+You can pass parameters to workflows when triggering them:
+
+```ts
+// Trigger a workflow with parameters
+const result = await sdk.triggerAndWait("myWorkflow", {
+  workflowParams: {
+    userId: "123",
+    action: "create",
+  },
+});
+```
+
+Inside the workflow, you can access the parameters through the `event` object:
+
+```ts
+const myWorkflow = workflow(async function* (step, event, logger) {
+  const { params } = event;
+
+  logger.info(`Processing action ${params.action} for user ${params.userId}`);
+
+  // Use the parameters in your workflow logic
+  // ...
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can pass parameters to workflows when triggering them:
 ```ts
 // Trigger a workflow with parameters
 const result = await sdk.triggerAndWait("myWorkflow", {
-  workflowParams: {
+  params: {
     userId: "123",
     action: "create",
   },

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ const myWorkflow = workflow(async function* (step, event, logger) {
 You can pass parameters to workflows when triggering them:
 
 ```ts
-// Trigger a workflow with parameters
-const result = await sdk.triggerAndWait("myWorkflow", {
+const result = await sdk.triggerAndWait({
+  workflowId: "myWorkflow",
   params: {
     userId: "123",
     action: "create",

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
     },
     "packages/bun-http-server": {
       "name": "@yieldstar/bun-http-server",
+      "version": "0.1.4",
       "dependencies": {
         "@yieldstar/core": "packages/core",
         "pino": "^9.4.0",
@@ -25,6 +26,7 @@
     },
     "packages/bun-sqlite-runtime": {
       "name": "@yieldstar/bun-sqlite-runtime",
+      "version": "0.1.4",
       "dependencies": {
         "@yieldstar/core": "packages/core",
       },
@@ -34,6 +36,7 @@
     },
     "packages/bun-worker-invoker": {
       "name": "@yieldstar/bun-worker-invoker",
+      "version": "0.1.4",
       "dependencies": {
         "@yieldstar/core": "packages/core",
         "pino": "^9.4.0",
@@ -44,6 +47,7 @@
     },
     "packages/core": {
       "name": "@yieldstar/core",
+      "version": "0.1.4",
       "devDependencies": {
         "@types/bun": "latest",
       },
@@ -53,6 +57,7 @@
     },
     "packages/test-invoker": {
       "name": "@yieldstar/test-invoker",
+      "version": "0.1.4",
       "dependencies": {
         "@yieldstar/core": "packages/core",
         "pino": "^9.4.0",
@@ -63,6 +68,7 @@
     },
     "packages/test-runtime": {
       "name": "@yieldstar/test-runtime",
+      "version": "0.1.4",
       "devDependencies": {
         "@types/bun": "latest",
         "@yieldstar/core": "packages/core",
@@ -70,6 +76,7 @@
     },
     "packages/test-utils": {
       "name": "@yieldstar/test-utils",
+      "version": "0.1.4",
       "dependencies": {
         "@yieldstar/core": "packages/core",
         "@yieldstar/test-invoker": "packages/test-invoker",
@@ -79,12 +86,14 @@
     },
     "packages/yieldstar": {
       "name": "yieldstar",
+      "version": "0.1.5-alpha.1",
       "dependencies": {
         "serialize-error": "^11.0.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@yieldstar/core": "packages/core",
+        "@yieldstar/core": "workspace:*",
+        "pino": "^9.6.0",
       },
     },
   },
@@ -289,7 +298,7 @@
 
     "@yieldstar/bun-worker-invoker/@types/bun": ["@types/bun@1.1.10", "", { "dependencies": { "bun-types": "1.1.29" } }, "sha512-76KYVSwrHwr9zsnk6oLXOGs9KvyBg3U066GLO4rk6JZk1ypEPGCUDZ5yOiESyIHWs9cx9iC8r01utYN32XdmgA=="],
 
-    "@yieldstar/core/@types/bun": ["@types/bun@1.1.10", "", { "dependencies": { "bun-types": "1.1.29" } }, "sha512-76KYVSwrHwr9zsnk6oLXOGs9KvyBg3U066GLO4rk6JZk1ypEPGCUDZ5yOiESyIHWs9cx9iC8r01utYN32XdmgA=="],
+    "@yieldstar/core/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
 
     "@yieldstar/test-invoker/@types/bun": ["@types/bun@1.1.10", "", { "dependencies": { "bun-types": "1.1.29" } }, "sha512-76KYVSwrHwr9zsnk6oLXOGs9KvyBg3U066GLO4rk6JZk1ypEPGCUDZ5yOiESyIHWs9cx9iC8r01utYN32XdmgA=="],
 
@@ -305,7 +314,9 @@
 
     "readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
-    "yieldstar/@types/bun": ["@types/bun@1.1.10", "", { "dependencies": { "bun-types": "1.1.29" } }, "sha512-76KYVSwrHwr9zsnk6oLXOGs9KvyBg3U066GLO4rk6JZk1ypEPGCUDZ5yOiESyIHWs9cx9iC8r01utYN32XdmgA=="],
+    "yieldstar/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+
+    "yieldstar/pino": ["pino@9.6.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^4.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg=="],
 
     "@yieldstar/bun-http-server/@types/bun/bun-types": ["bun-types@1.1.29", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-En3/TzSPMPyl5UlUB1MHzHpcrZDakTm7mS203eLoX1fBoEa3PW+aSS8GAqVJ7Is/m34Z5ogL+ECniLY0uDaCPw=="],
 
@@ -313,12 +324,14 @@
 
     "@yieldstar/bun-worker-invoker/@types/bun/bun-types": ["bun-types@1.1.29", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-En3/TzSPMPyl5UlUB1MHzHpcrZDakTm7mS203eLoX1fBoEa3PW+aSS8GAqVJ7Is/m34Z5ogL+ECniLY0uDaCPw=="],
 
-    "@yieldstar/core/@types/bun/bun-types": ["bun-types@1.1.29", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-En3/TzSPMPyl5UlUB1MHzHpcrZDakTm7mS203eLoX1fBoEa3PW+aSS8GAqVJ7Is/m34Z5ogL+ECniLY0uDaCPw=="],
+    "@yieldstar/core/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "@yieldstar/test-invoker/@types/bun/bun-types": ["bun-types@1.1.29", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-En3/TzSPMPyl5UlUB1MHzHpcrZDakTm7mS203eLoX1fBoEa3PW+aSS8GAqVJ7Is/m34Z5ogL+ECniLY0uDaCPw=="],
 
     "@yieldstar/test-runtime/@types/bun/bun-types": ["bun-types@1.1.29", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-En3/TzSPMPyl5UlUB1MHzHpcrZDakTm7mS203eLoX1fBoEa3PW+aSS8GAqVJ7Is/m34Z5ogL+ECniLY0uDaCPw=="],
 
-    "yieldstar/@types/bun/bun-types": ["bun-types@1.1.29", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-En3/TzSPMPyl5UlUB1MHzHpcrZDakTm7mS203eLoX1fBoEa3PW+aSS8GAqVJ7Is/m34Z5ogL+ECniLY0uDaCPw=="],
+    "yieldstar/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+
+    "yieldstar/pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
   }
 }

--- a/examples/http-server/app.ts
+++ b/examples/http-server/app.ts
@@ -5,7 +5,11 @@ export const createSdk = createHttpSdkFactory<WorkflowRouter>();
 const sdk = createSdk({ host: "localhost", port: 8080 });
 
 try {
-  const result = await sdk.triggerAndWait("simple-workflow");
+  const result = await sdk.triggerAndWait("dynamic-workflow", {
+    params: {
+      msg: "world",
+    },
+  });
   console.log(result);
 } catch (err) {
   console.error(err);

--- a/examples/http-server/app.ts
+++ b/examples/http-server/app.ts
@@ -5,7 +5,8 @@ export const createSdk = createHttpSdkFactory<WorkflowRouter>();
 const sdk = createSdk({ host: "localhost", port: 8080 });
 
 try {
-  const result = await sdk.triggerAndWait("dynamic-workflow", {
+  const result = await sdk.triggerAndWait({
+    workflowId: "dynamic-workflow",
     params: {
       msg: "world",
     },

--- a/examples/http-server/server.ts
+++ b/examples/http-server/server.ts
@@ -17,5 +17,5 @@ const server = createWorkflowHttpServer({
   invoker,
 });
 
-sqliteEventLoop.start({ onNewTask: invoker.execute, logger });
+sqliteEventLoop.start({ onNewEvent: invoker.execute, logger });
 server.serve();

--- a/examples/local-execution/app.ts
+++ b/examples/local-execution/app.ts
@@ -13,7 +13,10 @@ export const sdk = createLocalSdk<WorkflowRouter>(invoker);
 sqliteEventLoop.start({ onNewEvent: invoker.execute, logger });
 
 try {
-  const result = await sdk.triggerAndWait("simple-workflow");
+  const result = await sdk.triggerAndWait({
+    workflowId: "dynamic-workflow",
+    params: { msg: "hello" },
+  });
   console.log(result);
 } finally {
   sqliteEventLoop.stop();

--- a/examples/local-execution/app.ts
+++ b/examples/local-execution/app.ts
@@ -10,7 +10,7 @@ const workerPath = new URL("worker.ts", import.meta.url).href;
 export const invoker = createWorkflowInvoker({ workerPath, logger });
 export const sdk = createLocalSdk<WorkflowRouter>(invoker);
 
-sqliteEventLoop.start({ onNewTask: invoker.execute, logger });
+sqliteEventLoop.start({ onNewEvent: invoker.execute, logger });
 
 try {
   const result = await sdk.triggerAndWait("simple-workflow");

--- a/examples/local-execution/shared.ts
+++ b/examples/local-execution/shared.ts
@@ -1,6 +1,7 @@
 import { createWorkflowRouter } from "yieldstar";
 import { SqliteEventLoop, createSqliteDb } from "@yieldstar/bun-sqlite-runtime";
 import { simpleWorkflow } from "../workflows/simple";
+import { dynamicWorkflow } from "../workflows/dynamic";
 
 export const runtimeDb = createSqliteDb({
   path: "./.db/local-execution.sqlite",
@@ -9,6 +10,7 @@ export const sqliteEventLoop = new SqliteEventLoop(runtimeDb);
 
 export const workflowRouter = createWorkflowRouter({
   "simple-workflow": simpleWorkflow,
+  "dynamic-workflow": dynamicWorkflow,
 });
 
 export type WorkflowRouter = typeof workflowRouter;

--- a/examples/params.ts
+++ b/examples/params.ts
@@ -2,11 +2,25 @@ import { workflow } from "yieldstar";
 import { createWorkflowTestRunner } from "@yieldstar/test-utils";
 import pino from "pino";
 
-// Create a logger
 const logger = pino({ level: "info" });
 
-// Define a workflow that uses parameters
-const userWorkflow = workflow(async function* (step, event, logger) {
+type Params = {
+  userId: string;
+  name: string;
+  role: string;
+  action: string;
+};
+
+type Result = {
+  success: boolean;
+  message: string;
+};
+
+const userWorkflow = workflow<Params, Result>(async function* (
+  step,
+  event,
+  logger
+) {
   const { params } = event;
 
   logger.info(`Starting workflow for user ${params?.userId || "unknown"}`);

--- a/examples/params.ts
+++ b/examples/params.ts
@@ -39,6 +39,11 @@ const userWorkflow = workflow<Params, Result>(async function* (
     };
   });
 
+  yield* step.poll({ retryInterval: 1000, maxAttempts: 5 }, async () => {
+    logger.info(`Polling user data for user ${params?.userId}`);
+    return false;
+  });
+
   // Step 2: Process user data based on action
   const result = yield* step.run("processUserData", async () => {
     const action = params?.action || "view";

--- a/examples/params.ts
+++ b/examples/params.ts
@@ -1,0 +1,98 @@
+import { workflow } from "yieldstar";
+import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import pino from "pino";
+
+// Create a logger
+const logger = pino({ level: "info" });
+
+// Define a workflow that uses parameters
+const userWorkflow = workflow(async function* (step, event, logger) {
+  const { params } = event;
+
+  logger.info(`Starting workflow for user ${params?.userId || "unknown"}`);
+
+  // Step 1: Fetch user data
+  const userData = yield* step.run("fetchUserData", async () => {
+    logger.info(`Fetching data for user ${params?.userId}`);
+
+    // Simulate API call
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    return {
+      id: params?.userId,
+      name: params?.name || "Anonymous",
+      role: params?.role || "user",
+    };
+  });
+
+  // Step 2: Process user data based on action
+  const result = yield* step.run("processUserData", async () => {
+    const action = params?.action || "view";
+    logger.info(`Processing action "${action}" for user ${userData.id}`);
+
+    // Simulate processing
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    switch (action) {
+      case "create":
+        return {
+          success: true,
+          message: `User ${userData.name} created successfully`,
+        };
+      case "update":
+        return {
+          success: true,
+          message: `User ${userData.name} updated successfully`,
+        };
+      case "delete":
+        return {
+          success: true,
+          message: `User ${userData.name} deleted successfully`,
+        };
+      default:
+        return {
+          success: true,
+          message: `User ${userData.name} viewed successfully`,
+        };
+    }
+  });
+
+  logger.info(`Workflow completed with result: ${JSON.stringify(result)}`);
+
+  return result;
+});
+
+// Create a test runner
+const runner = createWorkflowTestRunner({ logger });
+
+// Run the workflow with different parameters
+async function runExample() {
+  // Example 1: Create a new user
+  const result1 = await runner.triggerAndWait(userWorkflow, {
+    params: {
+      userId: "123",
+      name: "John Doe",
+      role: "admin",
+      action: "create",
+    },
+  });
+  console.log("Example 1 Result:", result1);
+
+  // Example 2: Update an existing user
+  const result2 = await runner.triggerAndWait(userWorkflow, {
+    params: {
+      userId: "456",
+      name: "Jane Smith",
+      role: "manager",
+      action: "update",
+    },
+  });
+  console.log("Example 2 Result:", result2);
+
+  // Example 3: No parameters (defaults will be used)
+  const result3 = await runner.triggerAndWait(userWorkflow);
+  console.log("Example 3 Result:", result3);
+}
+
+// Run the example
+runExample().catch(console.error);

--- a/examples/workflows/cache-keys.ts
+++ b/examples/workflows/cache-keys.ts
@@ -1,8 +1,8 @@
-import { createWorkflow } from "yieldstar";
+import { workflow } from "yieldstar";
 
 let executionIdx = -1;
 
-export const cacheKeysWorkflow = createWorkflow(async function* (step) {
+export const cacheKeysWorkflow = workflow(async function* (step) {
   executionIdx++;
   let volatileNum = 0;
   let stableNum = 0;

--- a/examples/workflows/coordinator.ts
+++ b/examples/workflows/coordinator.ts
@@ -1,13 +1,14 @@
-import type { WorkflowFn } from "yieldstar";
-import { createWorkflow } from "yieldstar";
 import type { Logger } from "pino";
-type CustomWorkflowFn<T> = (
-  step: Parameters<WorkflowFn<T>>[0],
+import type { WorkflowFn } from "yieldstar";
+import { workflow } from "yieldstar";
+
+type CustomWorkflowFn<Params, Result> = (
+  step: Parameters<WorkflowFn<Params, Result>>[0],
   waitForState: (s: string) => AsyncGenerator
-) => AsyncGenerator<any, T>;
+) => AsyncGenerator<any, Result>;
 
 // essentially a custom step
-const waitForStateFactory = (step: any, logger: Logger) =>
+const waitForStateFactory = (step: any, event: any, logger: Logger) =>
   async function* (state: string) {
     yield* step.poll({ maxAttempts: 10, retryInterval: 1000 }, () => {
       logger.info("Polling...");
@@ -16,9 +17,11 @@ const waitForStateFactory = (step: any, logger: Logger) =>
     });
   };
 
-const workflowFactory = (workflowFn: CustomWorkflowFn<any>) => {
-  return createWorkflow(async function* (step, logger) {
-    const waitForState = waitForStateFactory(step, logger);
+const workflowFactory = <Params, Result>(
+  workflowFn: CustomWorkflowFn<Params, Result>
+) => {
+  return workflow(async function* (step, event, logger) {
+    const waitForState = waitForStateFactory(step, event, logger);
     return yield* workflowFn(step, waitForState);
   });
 };

--- a/examples/workflows/dynamic.ts
+++ b/examples/workflows/dynamic.ts
@@ -1,4 +1,4 @@
-import { createWorkflow } from "yieldstar";
+import { workflow } from "yieldstar";
 
 const workflowPlan = [
   { type: "get-number" },
@@ -7,7 +7,7 @@ const workflowPlan = [
   { type: "fail" },
 ] as const;
 
-export const dynamicWorkflow = createWorkflow(async function* (step, logger) {
+export const dynamicWorkflow = workflow(async function* (step, event, logger) {
   let lastResult: any;
   for (const action of workflowPlan) {
     switch (action.type) {

--- a/examples/workflows/dynamic.ts
+++ b/examples/workflows/dynamic.ts
@@ -7,7 +7,11 @@ const workflowPlan = [
   { type: "fail" },
 ] as const;
 
-export const dynamicWorkflow = workflow(async function* (step, event, logger) {
+export const dynamicWorkflow = workflow<{ msg: string }, void>(async function* (
+  step,
+  event,
+  logger
+) {
   let lastResult: any;
   for (const action of workflowPlan) {
     switch (action.type) {
@@ -19,7 +23,7 @@ export const dynamicWorkflow = workflow(async function* (step, event, logger) {
         break;
       case "log":
         yield* step.run(() => {
-          logger.info("Logging: ", lastResult);
+          logger.info(`Hello ${event.params.msg}: ${lastResult}`);
         });
         break;
       case "fail":

--- a/examples/workflows/errors.ts
+++ b/examples/workflows/errors.ts
@@ -1,6 +1,6 @@
-import { createWorkflow, RetryableError } from "yieldstar";
+import { workflow, RetryableError } from "yieldstar";
 
-export const errorsWorkflow = createWorkflow(async function* (step, logger) {
+export const errorsWorkflow = workflow(async function* (step, event, logger) {
   let num = yield* step.run(() => {
     logger.info("In step 1");
     return 1;

--- a/examples/workflows/loop.ts
+++ b/examples/workflows/loop.ts
@@ -1,6 +1,6 @@
-import { createWorkflow } from "yieldstar";
+import { workflow } from "yieldstar";
 
-export const loopWorkflow = createWorkflow(async function* (step, logger) {
+export const loopWorkflow = workflow(async function* (step, event, logger) {
   let numbers: number[] = [];
 
   let i = 0;

--- a/examples/workflows/polling.ts
+++ b/examples/workflows/polling.ts
@@ -1,6 +1,6 @@
-import { createWorkflow } from "yieldstar";
+import { workflow } from "yieldstar";
 
-export const pollingWorkflow = createWorkflow(async function* (step, logger) {
+export const pollingWorkflow = workflow(async function* (step, event, logger) {
   let num: number;
 
   yield* step.poll({ retryInterval: 1000, maxAttempts: 10 }, () => {

--- a/examples/workflows/simple.ts
+++ b/examples/workflows/simple.ts
@@ -1,6 +1,6 @@
-import { createWorkflow } from "yieldstar";
+import { workflow } from "yieldstar";
 
-export const simpleWorkflow = createWorkflow(async function* (step, logger) {
+export const simpleWorkflow = workflow(async function* (step, event, logger) {
   let num = yield* step.run(() => {
     logger.info("In step 1");
     return 1;

--- a/packages/bun-http-server/src/bun-server.ts
+++ b/packages/bun-http-server/src/bun-server.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { Task, WorkflowInvoker } from "@yieldstar/core";
+import type { ExecutionEvent, WorkflowInvoker } from "@yieldstar/core";
 import { serializeError } from "serialize-error";
 
 export function createWorkflowHttpServer(params: {
@@ -12,6 +12,11 @@ export function createWorkflowHttpServer(params: {
     serve() {
       return Bun.serve({
         port: port,
+        websocket: {
+          message() {},
+          open() {},
+          close() {},
+        },
         async fetch(req) {
           const url = new URL(req.url);
 
@@ -20,36 +25,37 @@ export function createWorkflowHttpServer(params: {
               executionId: string;
             };
 
-            if (!executionId) {
-              return new Response("Missing executionId", { status: 400 });
-            }
-
-            const result = await new Promise((resolve) => {
-              invoker.workflowEndEmitter.once(executionId, resolve);
+            return new Promise((resolve) => {
+              invoker.workflowEndEmitter.once(executionId, (result) => {
+                resolve(
+                  new Response(JSON.stringify(result), {
+                    headers: { "Content-Type": "application/json" },
+                  })
+                );
+              });
             });
-
-            if (result instanceof Error) {
-              return Response.json(serializeError(result));
-            }
-
-            return Response.json(result);
           }
 
           if (url.pathname === "/trigger") {
             try {
-              const task = (await req.json()) as Task;
-              await invoker.execute(task);
-              return Response.json(
-                { executionId: task.executionId },
-                { status: 202 }
+              const body = (await req.json()) as ExecutionEvent;
+              await invoker.execute(body);
+              return new Response(
+                JSON.stringify({ executionId: body.executionId }),
+                {
+                  headers: { "Content-Type": "application/json" },
+                }
               );
             } catch (err: any) {
               logger.error(err);
-              return Response.json(err.message, { status: 400 });
+              return new Response(JSON.stringify(serializeError(err)), {
+                status: 500,
+                headers: { "Content-Type": "application/json" },
+              });
             }
           }
 
-          return new Response("Not Found", { status: 404 });
+          return new Response("Not found", { status: 404 });
         },
       });
     },

--- a/packages/bun-http-server/src/bun-server.ts
+++ b/packages/bun-http-server/src/bun-server.ts
@@ -12,11 +12,6 @@ export function createWorkflowHttpServer(params: {
     serve() {
       return Bun.serve({
         port: port,
-        websocket: {
-          message() {},
-          open() {},
-          close() {},
-        },
         async fetch(req) {
           const url = new URL(req.url);
 
@@ -25,37 +20,36 @@ export function createWorkflowHttpServer(params: {
               executionId: string;
             };
 
-            return new Promise((resolve) => {
-              invoker.workflowEndEmitter.once(executionId, (result) => {
-                resolve(
-                  new Response(JSON.stringify(result), {
-                    headers: { "Content-Type": "application/json" },
-                  })
-                );
-              });
+            if (!executionId) {
+              return new Response("Missing executionId", { status: 400 });
+            }
+
+            const result = await new Promise((resolve) => {
+              invoker.workflowEndEmitter.once(executionId, resolve);
             });
+
+            if (result instanceof Error) {
+              return Response.json(serializeError(result));
+            }
+
+            return Response.json(result);
           }
 
           if (url.pathname === "/trigger") {
             try {
-              const body = (await req.json()) as ExecutionEvent;
-              await invoker.execute(body);
-              return new Response(
-                JSON.stringify({ executionId: body.executionId }),
-                {
-                  headers: { "Content-Type": "application/json" },
-                }
+              const event = (await req.json()) as ExecutionEvent;
+              await invoker.execute(event);
+              return Response.json(
+                { executionId: event.executionId },
+                { status: 202 }
               );
             } catch (err: any) {
               logger.error(err);
-              return new Response(JSON.stringify(serializeError(err)), {
-                status: 500,
-                headers: { "Content-Type": "application/json" },
-              });
+              return Response.json(err.message, { status: 400 });
             }
           }
 
-          return new Response("Not found", { status: 404 });
+          return new Response("Not Found", { status: 404 });
         },
       });
     },

--- a/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
+++ b/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import type { Task } from "@yieldstar/core";
+import type { ExecutionEvent } from "@yieldstar/core";
 
 class TaskRow {
   task_id!: number;
@@ -20,20 +20,20 @@ export class TaskQueueDao {
   }
 
   setupDb() {
-    this.db.run(`
+    this.db.exec(`
       CREATE TABLE IF NOT EXISTS task_queue (
         task_id INTEGER PRIMARY KEY AUTOINCREMENT,
         workflow_id TEXT NOT NULL,
         execution_id TEXT NOT NULL,
         params TEXT,
-        visible_from INTEGER DEFAULT 0
-      );
+        visible_from INTEGER DEFAULT (strftime('%s', 'now'))
+      )
     `);
   }
 
-  insertTask(task: Task) {
-    const query = this.db.query(
-      `INSERT INTO task_queue (workflow_id, execution_id, params) 
+  insertTask(task: ExecutionEvent) {
+    const query = this.db.prepare(
+      `INSERT INTO task_queue (workflow_id, execution_id, params)
       VALUES ($workflowId, $executionId, $params)`
     );
 
@@ -45,38 +45,31 @@ export class TaskQueueDao {
   }
 
   getNextTask() {
-    const query = this.db
-      .query(
-        `SELECT * FROM task_queue WHERE visible_from < strftime('%s', 'now') ORDER BY task_id LIMIT 1`
-      )
-      .as(TaskRow);
-
-    return query.get();
+    const query = this.db.prepare(
+      `SELECT * FROM task_queue WHERE visible_from < strftime('%s', 'now') ORDER BY task_id LIMIT 1`
+    );
+    return query.get() as TaskRow | undefined;
   }
 
   updateTaskVisibility(taskId: number, visibleFrom: number) {
-    this.db
-      .query(
-        "UPDATE task_queue SET visible_from = $visibleFrom WHERE task_id = $taskId"
-      )
-      .run({ $taskId: taskId, $visibleFrom: visibleFrom / 1000 });
+    const query = this.db.prepare(
+      "UPDATE task_queue SET visible_from = $visibleFrom WHERE task_id = $taskId"
+    );
+    query.run({ $taskId: taskId, $visibleFrom: visibleFrom });
   }
 
   deleteTaskById(id: number) {
-    const query = this.db.query(
+    const query = this.db.prepare(
       `DELETE FROM task_queue WHERE task_id = $taskId`
     );
     query.run({ $taskId: id });
   }
 
   getTaskCount() {
-    const query = this.db
-      .query(
-        `SELECT COUNT(*) as count FROM task_queue WHERE visible_from < strftime('%s', 'now')`
-      )
-      .as(CountRow);
-
-    const count = query.get()!;
-    return count.count;
+    const query = this.db.prepare(
+      `SELECT COUNT(*) as count FROM task_queue WHERE visible_from < strftime('%s', 'now')`
+    );
+    const result = query.get() as CountRow;
+    return result.count;
   }
 }

--- a/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
+++ b/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
@@ -31,16 +31,16 @@ export class TaskQueueDao {
     `);
   }
 
-  insertTask(task: ExecutionEvent) {
+  insertTask(event: ExecutionEvent) {
     const query = this.db.prepare(
       `INSERT INTO task_queue (workflow_id, execution_id, params)
       VALUES ($workflowId, $executionId, $params)`
     );
 
     query.run({
-      $workflowId: task.workflowId,
-      $executionId: task.executionId,
-      $params: task.params ? JSON.stringify(task.params) : null,
+      $workflowId: event.workflowId,
+      $executionId: event.executionId,
+      $params: event.params ? JSON.stringify(event.params) : null,
     });
   }
 

--- a/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
+++ b/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
@@ -5,6 +5,7 @@ class TaskRow {
   task_id!: number;
   workflow_id!: string;
   execution_id!: string;
+  params?: string;
 }
 
 class CountRow {
@@ -24,6 +25,7 @@ export class TaskQueueDao {
         task_id INTEGER PRIMARY KEY AUTOINCREMENT,
         workflow_id TEXT NOT NULL,
         execution_id TEXT NOT NULL,
+        params TEXT,
         visible_from INTEGER DEFAULT 0
       );
     `);
@@ -31,13 +33,14 @@ export class TaskQueueDao {
 
   insertTask(task: Task) {
     const query = this.db.query(
-      `INSERT INTO task_queue (workflow_id, execution_id) 
-      VALUES ($workflowId, $executionId)`
+      `INSERT INTO task_queue (workflow_id, execution_id, params) 
+      VALUES ($workflowId, $executionId, $params)`
     );
 
     query.run({
       $workflowId: task.workflowId,
       $executionId: task.executionId,
+      $params: task.params ? JSON.stringify(task.params) : null,
     });
   }
 

--- a/packages/bun-sqlite-runtime/src/dao/timers-dao.ts
+++ b/packages/bun-sqlite-runtime/src/dao/timers-dao.ts
@@ -1,3 +1,4 @@
+import type { ExecutionEvent } from "@yieldstar/core";
 import { Database } from "bun:sqlite";
 
 class TimerRow {
@@ -59,12 +60,7 @@ export class TimersDao {
     return count.count;
   }
 
-  insertTimer(
-    delay: number,
-    workflowId: string,
-    executionId: string,
-    params?: any
-  ) {
+  insertTimer(event: ExecutionEvent, delay: number) {
     const query = this.db.query(
       `INSERT INTO scheduled_tasks (delay, workflow_id, execution_id, created_at, params) 
       VALUES ($delay, $workflowId, $executionId, $createdAt, $params)`
@@ -72,10 +68,10 @@ export class TimersDao {
 
     query.run({
       $delay: delay,
-      $workflowId: workflowId,
-      $executionId: executionId,
+      $workflowId: event.workflowId,
+      $executionId: event.executionId,
       $createdAt: Date.now(),
-      $params: params ? JSON.stringify(params) : null,
+      $params: event.params ? JSON.stringify(event.params) : null,
     });
   }
 

--- a/packages/bun-sqlite-runtime/src/dao/timers-dao.ts
+++ b/packages/bun-sqlite-runtime/src/dao/timers-dao.ts
@@ -6,6 +6,7 @@ class TimerRow {
   workflow_id!: string;
   execution_id!: string;
   created_at!: number;
+  params?: string;
 }
 
 class CountRow {
@@ -27,7 +28,8 @@ export class TimersDao {
         delay INTEGER NOT NULL,
         workflow_id TEXT NOT NULL,
         execution_id TEXT NOT NULL,
-        created_at INTEGER NOT NULL
+        created_at INTEGER NOT NULL,
+        params TEXT
       );
     `);
   }
@@ -35,7 +37,7 @@ export class TimersDao {
   getExpiredTimers(): TimerRow[] {
     const query = this.db
       .query(
-        `SELECT id, delay, workflow_id, execution_id, created_at 
+        `SELECT id, delay, workflow_id, execution_id, created_at, params 
         FROM scheduled_tasks 
         WHERE (created_at + delay) < $currentTime`
       )
@@ -57,18 +59,23 @@ export class TimersDao {
     return count.count;
   }
 
-  insertTimer(delay: number, workflowId: string, executionId: string) {
-    const createdAt = Date.now();
-
+  insertTimer(
+    delay: number,
+    workflowId: string,
+    executionId: string,
+    params?: any
+  ) {
     const query = this.db.query(
-      `INSERT INTO scheduled_tasks (delay, workflow_id, execution_id, created_at) 
-        VALUES ($delay, $workflowId, $executionId, $createdAt)`
+      `INSERT INTO scheduled_tasks (delay, workflow_id, execution_id, created_at, params) 
+      VALUES ($delay, $workflowId, $executionId, $createdAt, $params)`
     );
+
     query.run({
       $delay: delay,
       $workflowId: workflowId,
       $executionId: executionId,
-      $createdAt: createdAt,
+      $createdAt: Date.now(),
+      $params: params ? JSON.stringify(params) : null,
     });
   }
 

--- a/packages/bun-sqlite-runtime/src/sqlite-event-loop.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-event-loop.ts
@@ -23,19 +23,19 @@ export class SqliteEventLoop {
     this.isRunning = false;
   }
 
-  private async loop(processTask: EventProcessor, logger: Logger) {
+  private async loop(processEvent: EventProcessor, logger: Logger) {
     if (!this.isRunning) return;
 
     while (!this.taskQueue.isEmpty) {
       const task = this.taskQueue.process();
       if (task) {
-        await processTask(task, logger);
+        await processEvent(task.event, logger);
         this.taskQueue.remove(task.taskId);
       }
     }
 
     this.timers.processTimers();
 
-    setTimeout(() => this.loop(processTask, logger), 10);
+    setTimeout(() => this.loop(processEvent, logger), 10);
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-event-loop.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-event-loop.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { SqliteTaskQueue } from "./sqlite-task-queue";
 import { SqliteTimers } from "./sqlite-timers";
-import type { TaskProcessor } from "@yieldstar/core";
+import type { EventProcessor } from "@yieldstar/core";
 import type { Logger } from "pino";
 
 export class SqliteEventLoop {
@@ -14,16 +14,16 @@ export class SqliteEventLoop {
     this.timers = new SqliteTimers({ db, taskQueue: this.taskQueue });
   }
 
-  start(params: { onNewTask: TaskProcessor; logger: Logger }) {
+  start(params: { onNewEvent: EventProcessor; logger: Logger }) {
     this.isRunning = true;
-    this.loop(params.onNewTask, params.logger);
+    this.loop(params.onNewEvent, params.logger);
   }
 
   stop() {
     this.isRunning = false;
   }
 
-  private async loop(processTask: TaskProcessor, logger: Logger) {
+  private async loop(processTask: EventProcessor, logger: Logger) {
     if (!this.isRunning) return;
 
     while (!this.taskQueue.isEmpty) {

--- a/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
@@ -18,6 +18,7 @@ export class SqliteSchedulerClient implements SchedulerClient {
     workflowId: string;
     executionId: string;
     resumeIn?: number;
+    params?: any;
   }) {
     const { resumeIn, ...task } = params;
     if (resumeIn) {
@@ -25,6 +26,7 @@ export class SqliteSchedulerClient implements SchedulerClient {
         delay: resumeIn,
         workflowId: params.workflowId,
         executionId: params.executionId,
+        params: params.params,
       });
     } else {
       this.taskQueue.add(task);

--- a/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
@@ -1,4 +1,4 @@
-import type { SchedulerClient } from "@yieldstar/core";
+import type { SchedulerClient, ExecutionEvent } from "@yieldstar/core";
 import { SqliteTaskQueueClient } from "./sqlite-task-queue";
 import { SqliteTimersClient } from "./sqlite-timers";
 
@@ -14,10 +14,7 @@ export class SqliteSchedulerClient implements SchedulerClient {
     this.timersClient = params.timersClient;
   }
 
-  async requestWakeUp(
-    event: { workflowId: string; executionId: string; params?: any },
-    resumeIn?: number
-  ) {
+  async requestWakeUp(event: ExecutionEvent, resumeIn?: number) {
     if (resumeIn) {
       this.timersClient.createTimer(event, resumeIn);
     } else {

--- a/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
@@ -14,22 +14,14 @@ export class SqliteSchedulerClient implements SchedulerClient {
     this.timersClient = params.timersClient;
   }
 
-  async requestWakeUp(params: {
-    workflowId: string;
-    executionId: string;
-    resumeIn?: number;
-    params?: any;
-  }) {
-    const { resumeIn, ...task } = params;
+  async requestWakeUp(
+    event: { workflowId: string; executionId: string; params?: any },
+    resumeIn?: number
+  ) {
     if (resumeIn) {
-      this.timersClient.createTimer({
-        delay: resumeIn,
-        workflowId: params.workflowId,
-        executionId: params.executionId,
-        params: params.params,
-      });
+      this.timersClient.createTimer(event, resumeIn);
     } else {
-      this.taskQueue.add(task);
+      this.taskQueue.add(event);
     }
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import type { Task } from "@yieldstar/core";
+import type { ExecutionEvent } from "@yieldstar/core";
 import { TaskQueueDao } from "./dao/task-queue-dao";
 
 const VISIBILITY_WINDOW = 300000;
@@ -12,7 +12,7 @@ export class SqliteTaskQueue {
     this.taskQueueDao.setupDb();
   }
 
-  add(task: Task) {
+  add(task: ExecutionEvent) {
     this.taskQueueDao.insertTask(task);
   }
 
@@ -21,9 +21,8 @@ export class SqliteTaskQueue {
 
     if (!row) return undefined;
 
-    const now = Date.now();
-    const visibilityTimeout = now + VISIBILITY_WINDOW;
-
+    const visibilityTimeout =
+      Math.floor(Date.now() / 1000) + VISIBILITY_WINDOW / 1000;
     this.taskQueueDao.updateTaskVisibility(row.task_id, visibilityTimeout);
 
     return {
@@ -31,7 +30,6 @@ export class SqliteTaskQueue {
       workflowId: row.workflow_id,
       executionId: row.execution_id,
       params: row.params ? JSON.parse(row.params) : undefined,
-      visibilityTimeout,
     };
   }
 
@@ -50,10 +48,12 @@ export class SqliteTaskQueue {
 
 export class SqliteTaskQueueClient {
   private taskQueueDao: TaskQueueDao;
+
   constructor(db: Database) {
     this.taskQueueDao = new TaskQueueDao(db);
   }
-  add(task: Task) {
+
+  add(task: ExecutionEvent) {
     this.taskQueueDao.insertTask(task);
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
@@ -21,14 +21,16 @@ export class SqliteTaskQueue {
 
     if (!row) return undefined;
 
-    const visibilityTimeout =
-      Math.floor(Date.now() / 1000) + VISIBILITY_WINDOW / 1000;
+    const now = Date.now();
+    const visibilityTimeout = now + VISIBILITY_WINDOW;
+
     this.taskQueueDao.updateTaskVisibility(row.task_id, visibilityTimeout);
 
     return {
       taskId: row.task_id,
       workflowId: row.workflow_id,
       executionId: row.execution_id,
+      visibilityTimeout,
       params: row.params ? JSON.parse(row.params) : undefined,
     };
   }

--- a/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
@@ -12,8 +12,8 @@ export class SqliteTaskQueue {
     this.taskQueueDao.setupDb();
   }
 
-  add(task: ExecutionEvent) {
-    this.taskQueueDao.insertTask(task);
+  add(event: ExecutionEvent) {
+    this.taskQueueDao.insertTask(event);
   }
 
   process() {
@@ -28,10 +28,12 @@ export class SqliteTaskQueue {
 
     return {
       taskId: row.task_id,
-      workflowId: row.workflow_id,
-      executionId: row.execution_id,
       visibilityTimeout,
-      params: row.params ? JSON.parse(row.params) : undefined,
+      event: {
+        workflowId: row.workflow_id,
+        executionId: row.execution_id,
+        params: row.params ? JSON.parse(row.params) : undefined,
+      },
     };
   }
 
@@ -55,7 +57,7 @@ export class SqliteTaskQueueClient {
     this.taskQueueDao = new TaskQueueDao(db);
   }
 
-  add(task: ExecutionEvent) {
-    this.taskQueueDao.insertTask(task);
+  add(event: ExecutionEvent) {
+    this.taskQueueDao.insertTask(event);
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
@@ -30,6 +30,7 @@ export class SqliteTaskQueue {
       taskId: row.task_id,
       workflowId: row.workflow_id,
       executionId: row.execution_id,
+      params: row.params ? JSON.parse(row.params) : undefined,
       visibilityTimeout,
     };
   }

--- a/packages/bun-sqlite-runtime/src/sqlite-timers.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-timers.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { TimersDao } from "./dao/timers-dao";
 import { SqliteTaskQueue } from "./sqlite-task-queue";
 import type { ExecutionEvent } from "@yieldstar/core";
+
 export class SqliteTimers {
   private timersDao: TimersDao;
   private taskQueue: SqliteTaskQueue;

--- a/packages/bun-sqlite-runtime/src/sqlite-timers.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-timers.ts
@@ -31,17 +31,15 @@ export class SqliteTimersClient {
     this.timersDao = new TimersDao(db);
   }
 
-  createTimer(params: {
-    delay: number;
-    workflowId: string;
-    executionId: string;
-    params?: any;
-  }) {
+  createTimer(
+    event: { executionId: string; workflowId: string; params?: any },
+    delay: number
+  ) {
     this.timersDao.insertTimer(
-      params.delay,
-      params.workflowId,
-      params.executionId,
-      params.params
+      delay,
+      event.workflowId,
+      event.executionId,
+      event.params
     );
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-timers.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-timers.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { TimersDao } from "./dao/timers-dao";
 import { SqliteTaskQueue } from "./sqlite-task-queue";
-
+import type { ExecutionEvent } from "@yieldstar/core";
 export class SqliteTimers {
   private timersDao: TimersDao;
   private taskQueue: SqliteTaskQueue;
@@ -31,15 +31,7 @@ export class SqliteTimersClient {
     this.timersDao = new TimersDao(db);
   }
 
-  createTimer(
-    event: { executionId: string; workflowId: string; params?: any },
-    delay: number
-  ) {
-    this.timersDao.insertTimer(
-      delay,
-      event.workflowId,
-      event.executionId,
-      event.params
-    );
+  createTimer(event: ExecutionEvent, delay: number) {
+    this.timersDao.insertTimer(event, delay);
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-timers.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-timers.ts
@@ -18,6 +18,7 @@ export class SqliteTimers {
       this.taskQueue.add({
         workflowId: timer.workflow_id,
         executionId: timer.execution_id,
+        params: timer.params ? JSON.parse(timer.params) : undefined,
       });
     }
   }
@@ -34,11 +35,13 @@ export class SqliteTimersClient {
     delay: number;
     workflowId: string;
     executionId: string;
+    params?: any;
   }) {
     this.timersDao.insertTimer(
       params.delay,
       params.workflowId,
-      params.executionId
+      params.executionId,
+      params.params
     );
   }
 }

--- a/packages/bun-worker-invoker/src/bun-worker-invoker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker-invoker.ts
@@ -13,8 +13,8 @@ export function createWorkflowInvoker(params: {
   const { logger, workerPath } = params;
   return {
     workflowEndEmitter,
-    async execute(task: ExecutionEvent) {
-      const { executionId } = task;
+    async execute<Params>(event: ExecutionEvent<Params>) {
+      const { executionId } = event;
 
       const filePath = workerPath.startsWith("file:")
         ? fileURLToPath(workerPath)
@@ -48,7 +48,7 @@ export function createWorkflowInvoker(params: {
 
       logger.info({ executionId }, "Starting child process");
 
-      childProcess.send(task);
+      childProcess.send(event);
     },
   };
 }

--- a/packages/bun-worker-invoker/src/bun-worker-invoker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker-invoker.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { Task, WorkflowInvoker } from "@yieldstar/core";
+import type { ExecutionEvent, WorkflowInvoker } from "@yieldstar/core";
 import { EventEmitter } from "node:events";
 import { fileURLToPath } from "node:url";
 import { deserializeError } from "serialize-error";
@@ -13,7 +13,7 @@ export function createWorkflowInvoker(params: {
   const { logger, workerPath } = params;
   return {
     workflowEndEmitter,
-    async execute(task: Task) {
+    async execute(task: ExecutionEvent) {
       const { executionId } = task;
 
       const filePath = workerPath.startsWith("file:")

--- a/packages/bun-worker-invoker/src/bun-worker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker.ts
@@ -8,9 +8,9 @@ export function createWorkflowWorker(
 ) {
   return {
     listen() {
-      process.on("message", async (task: ExecutionEvent) => {
+      process.on("message", async (event: ExecutionEvent) => {
         try {
-          const response = await workflowRunner.run(task, logger);
+          const response = await workflowRunner.run(event, logger);
           process.send!({ status: "completed", response });
         } catch (error: any) {
           process.send!({ status: "error", error: serializeError(error) });

--- a/packages/bun-worker-invoker/src/bun-worker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { Task, WorkflowRunner } from "@yieldstar/core";
+import type { ExecutionEvent, WorkflowRunner } from "@yieldstar/core";
 import { serializeError } from "serialize-error";
 
 export function createWorkflowWorker(
@@ -8,7 +8,7 @@ export function createWorkflowWorker(
 ) {
   return {
     listen() {
-      process.on("message", async (task: Task) => {
+      process.on("message", async (task: ExecutionEvent) => {
         try {
           const response = await workflowRunner.run(task, logger);
           process.send!({ status: "completed", response });

--- a/packages/core/src/base/event.ts
+++ b/packages/core/src/base/event.ts
@@ -1,0 +1,38 @@
+/**
+ * The event object that a user passes when triggering a workflow.
+ */
+export type TriggerEvent<
+  Params extends Record<string, unknown> = Record<string, unknown>
+> = {
+  /**
+   * Optional execution ID for the workflow. If not provided, a random UUID will be generated.
+   */
+  executionId?: string;
+
+  /**
+   * Optional parameters to pass to the workflow.
+   */
+  params?: Params;
+};
+
+/**
+ * The event object that a workflow receives when it is executed.
+ */
+export type ExecutionEvent<
+  Params extends Record<string, unknown> = Record<string, unknown>
+> = {
+  /**
+   * The ID of the workflow to execute.
+   */
+  workflowId: string;
+
+  /**
+   * The unique execution ID for this workflow run.
+   */
+  executionId: string;
+
+  /**
+   * Optional parameters passed to the workflow.
+   */
+  params?: Params;
+};

--- a/packages/core/src/base/event.ts
+++ b/packages/core/src/base/event.ts
@@ -1,34 +1,20 @@
-/**
- * The event object that a user passes when triggering a workflow.
- */
-export type TriggerEvent<EventParams = any> = {
-  /**
-   * Optional execution ID for the workflow. If not provided, a random UUID will be generated.
-   */
-  executionId?: string;
+export type TriggerEvent<
+  WorkflowId extends string,
+  EventParams = any
+> = EventParams extends void
+  ? {
+      workflowId: WorkflowId;
+      executionId?: string;
+      params?: undefined;
+    }
+  : {
+      workflowId: WorkflowId;
+      executionId?: string;
+      params: EventParams;
+    };
 
-  /**
-   * Optional parameters to pass to the workflow.
-   */
-  params?: EventParams;
-};
-
-/**
- * The event object that a workflow receives when it is executed.
- */
 export type ExecutionEvent<EventParams = any> = {
-  /**
-   * The ID of the workflow to execute.
-   */
   workflowId: string;
-
-  /**
-   * The unique execution ID for this workflow run.
-   */
   executionId: string;
-
-  /**
-   * Optional parameters passed to the workflow.
-   */
   params: EventParams;
 };

--- a/packages/core/src/base/event.ts
+++ b/packages/core/src/base/event.ts
@@ -1,9 +1,7 @@
 /**
  * The event object that a user passes when triggering a workflow.
  */
-export type TriggerEvent<
-  Params extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type TriggerEvent<EventParams = any> = {
   /**
    * Optional execution ID for the workflow. If not provided, a random UUID will be generated.
    */
@@ -12,15 +10,13 @@ export type TriggerEvent<
   /**
    * Optional parameters to pass to the workflow.
    */
-  params?: Params;
+  params?: EventParams;
 };
 
 /**
  * The event object that a workflow receives when it is executed.
  */
-export type ExecutionEvent<
-  Params extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type ExecutionEvent<EventParams = any> = {
   /**
    * The ID of the workflow to execute.
    */
@@ -34,5 +30,5 @@ export type ExecutionEvent<
   /**
    * Optional parameters passed to the workflow.
    */
-  params?: Params;
+  params: EventParams;
 };

--- a/packages/core/src/base/invoker.ts
+++ b/packages/core/src/base/invoker.ts
@@ -1,7 +1,7 @@
 import type { EventEmitter } from "node:events";
-import type { Task } from "./runtime";
+import type { ExecutionEvent } from "./event";
 
 export type WorkflowInvoker = {
   workflowEndEmitter: EventEmitter;
-  execute(task: Task): Promise<void>;
+  execute(task: ExecutionEvent): Promise<void>;
 };

--- a/packages/core/src/base/invoker.ts
+++ b/packages/core/src/base/invoker.ts
@@ -3,5 +3,5 @@ import type { ExecutionEvent } from "./event";
 
 export type WorkflowInvoker = {
   workflowEndEmitter: EventEmitter;
-  execute(task: ExecutionEvent): Promise<void>;
+  execute<EventParams>(event: ExecutionEvent<EventParams>): Promise<void>;
 };

--- a/packages/core/src/base/runtime.ts
+++ b/packages/core/src/base/runtime.ts
@@ -1,9 +1,8 @@
 import type { Logger } from "pino";
 import type { WorkflowResult } from "./step";
-
-export type Task = { workflowId: string; executionId: string; params?: any };
+import type { ExecutionEvent } from "./event";
 
 export type TaskProcessor = <T = any>(
-  task: Task,
+  task: ExecutionEvent,
   logger: Logger
 ) => Promise<void | WorkflowResult<T>>;

--- a/packages/core/src/base/runtime.ts
+++ b/packages/core/src/base/runtime.ts
@@ -2,7 +2,7 @@ import type { Logger } from "pino";
 import type { WorkflowResult } from "./step";
 import type { ExecutionEvent } from "./event";
 
-export type TaskProcessor = <T = any>(
-  task: ExecutionEvent,
+export type EventProcessor<EventParams = any, Result = any> = (
+  event: ExecutionEvent<EventParams>,
   logger: Logger
-) => Promise<void | WorkflowResult<T>>;
+) => Promise<void | WorkflowResult<Result>>;

--- a/packages/core/src/base/scheduler.ts
+++ b/packages/core/src/base/scheduler.ts
@@ -3,5 +3,6 @@ export interface SchedulerClient {
     workflowId: string;
     executionId: string;
     resumeIn: number;
+    params?: any;
   }): Promise<void>;
 }

--- a/packages/core/src/base/scheduler.ts
+++ b/packages/core/src/base/scheduler.ts
@@ -1,5 +1,8 @@
 import type { ExecutionEvent } from "./event";
 
 export interface SchedulerClient {
-  requestWakeUp(params: ExecutionEvent, resumeIn?: number): Promise<void>;
+  requestWakeUp<EventParams>(
+    event: ExecutionEvent<EventParams>,
+    resumeIn?: number
+  ): Promise<void>;
 }

--- a/packages/core/src/base/scheduler.ts
+++ b/packages/core/src/base/scheduler.ts
@@ -1,8 +1,5 @@
+import type { ExecutionEvent } from "./event";
+
 export interface SchedulerClient {
-  requestWakeUp(params: {
-    workflowId: string;
-    executionId: string;
-    resumeIn: number;
-    params?: any;
-  }): Promise<void>;
+  requestWakeUp(params: ExecutionEvent, resumeIn?: number): Promise<void>;
 }

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -1,42 +1,29 @@
 import type { Logger } from "pino";
 import { HeapClient } from "./heap";
 import { StepResponse, WorkflowResult } from "./step";
+import type { ExecutionEvent } from "./event";
 
-export type WorkflowGeneratorParams = {
-  /**
-   * The ID of the workflow being executed.
-   */
-  workflowId: string;
-
-  /**
-   * The unique execution ID for this workflow run.
-   */
-  executionId: string;
-
-  /**
-   * The heap client for storing and retrieving workflow state.
-   */
+export type WorkflowGeneratorParams<EventParams> = {
+  event: ExecutionEvent<EventParams>;
   heapClient: HeapClient;
-
-  /**
-   * Logger instance for the workflow.
-   */
   logger: Logger;
-
-  /**
-   * Optional parameters passed to the workflow.
-   */
-  params?: any;
 };
 
-export type WorkflowGenerator<T = any> = (
-  params: WorkflowGeneratorParams
-) => AsyncGenerator<StepResponse, WorkflowResult<T>, StepResponse>;
+export type WorkflowGenerator<EventParams, Result> = (
+  genParams: WorkflowGeneratorParams<EventParams>
+) => AsyncGenerator<StepResponse, WorkflowResult<Result>, StepResponse>;
 
 export type WorkflowGeneratorReturnType<CG> = CG extends WorkflowGenerator<
-  infer T
+  infer EventParams,
+  infer Result
 >
-  ? T
+  ? Result
   : never;
 
-export type WorkflowRouter = Record<string, WorkflowGenerator>;
+export type WorkflowRouter = Record<string, WorkflowGenerator<any, any>>;
+
+export type EventOfWorkflow<W extends WorkflowGenerator<any, any>> =
+  Parameters<W>[0]["event"];
+
+export type ParamsOfWorkflow<W extends WorkflowGenerator<any, any>> =
+  Parameters<W>[0]["event"]["params"];

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -25,5 +25,5 @@ export type WorkflowRouter = Record<string, WorkflowGenerator<any, any>>;
 export type EventOfWorkflow<W extends WorkflowGenerator<any, any>> =
   Parameters<W>[0]["event"];
 
-export type EventParamsOfWorkflow<W extends WorkflowGenerator<any, any>> =
+export type EventParamsOf<W extends WorkflowGenerator<any, any>> =
   Parameters<W>[0]["event"]["params"];

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -2,12 +2,36 @@ import type { Logger } from "pino";
 import { HeapClient } from "./heap";
 import { StepResponse, WorkflowResult } from "./step";
 
-export type WorkflowGenerator<T = any> = (params: {
+export type WorkflowGeneratorParams = {
+  /**
+   * The ID of the workflow being executed.
+   */
+  workflowId: string;
+
+  /**
+   * The unique execution ID for this workflow run.
+   */
   executionId: string;
+
+  /**
+   * The heap client for storing and retrieving workflow state.
+   */
   heapClient: HeapClient;
+
+  /**
+   * Logger instance for the workflow.
+   */
   logger: Logger;
+
+  /**
+   * Optional parameters passed to the workflow.
+   */
   params?: any;
-}) => AsyncGenerator<StepResponse, WorkflowResult<T>, StepResponse>;
+};
+
+export type WorkflowGenerator<T = any> = (
+  params: WorkflowGeneratorParams
+) => AsyncGenerator<StepResponse, WorkflowResult<T>, StepResponse>;
 
 export type WorkflowGeneratorReturnType<CG> = CG extends WorkflowGenerator<
   infer T

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -25,5 +25,5 @@ export type WorkflowRouter = Record<string, WorkflowGenerator<any, any>>;
 export type EventOfWorkflow<W extends WorkflowGenerator<any, any>> =
   Parameters<W>[0]["event"];
 
-export type ParamsOfWorkflow<W extends WorkflowGenerator<any, any>> =
+export type EventParamsOfWorkflow<W extends WorkflowGenerator<any, any>> =
   Parameters<W>[0]["event"]["params"];

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -6,6 +6,7 @@ export type WorkflowGenerator<T = any> = (params: {
   executionId: string;
   heapClient: HeapClient;
   logger: Logger;
+  params?: any;
 }) => AsyncGenerator<StepResponse, WorkflowResult<T>, StepResponse>;
 
 export type WorkflowGeneratorReturnType<CG> = CG extends WorkflowGenerator<

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,16 @@
 export type { HeapClient, HeapRecord } from "./base/heap";
 export type { WorkflowInvoker } from "./base/invoker";
-export type { Task, TaskProcessor } from "./base/runtime";
+export type { TaskProcessor } from "./base/runtime";
 export type { SchedulerClient } from "./base/scheduler";
 export type {
   WorkflowGenerator,
   WorkflowGeneratorReturnType,
   WorkflowRouter,
 } from "./base/workflow";
+export type {
+  TriggerEvent as TriggerEvent,
+  ExecutionEvent as ExecutionEvent,
+} from "./base/event";
 
 export {
   StepCacheCheck,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export type {
   WorkflowGeneratorReturnType,
   WorkflowRouter,
   EventOfWorkflow,
-  EventParamsOfWorkflow,
+  EventParamsOf,
 } from "./base/workflow";
 export type {
   TriggerEvent as TriggerEvent,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,13 @@
 export type { HeapClient, HeapRecord } from "./base/heap";
 export type { WorkflowInvoker } from "./base/invoker";
-export type { TaskProcessor } from "./base/runtime";
+export type { EventProcessor } from "./base/runtime";
 export type { SchedulerClient } from "./base/scheduler";
 export type {
   WorkflowGenerator,
   WorkflowGeneratorReturnType,
   WorkflowRouter,
+  EventOfWorkflow,
+  ParamsOfWorkflow,
 } from "./base/workflow";
 export type {
   TriggerEvent as TriggerEvent,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export type {
   WorkflowGeneratorReturnType,
   WorkflowRouter,
   EventOfWorkflow,
-  ParamsOfWorkflow,
+  EventParamsOfWorkflow,
 } from "./base/workflow";
 export type {
   TriggerEvent as TriggerEvent,

--- a/packages/core/src/lib/workflow-runner.ts
+++ b/packages/core/src/lib/workflow-runner.ts
@@ -26,7 +26,7 @@ export class WorkflowRunner<
   }
 
   run: TaskProcessor = async (task, logger) => {
-    const { workflowId, executionId } = task;
+    const { workflowId, executionId, params } = task;
     const workflow = this.router[workflowId];
 
     if (!workflow) {
@@ -38,6 +38,7 @@ export class WorkflowRunner<
         executionId,
         workflow,
         logger,
+        params,
       });
 
       switch (response.type) {
@@ -49,6 +50,7 @@ export class WorkflowRunner<
             workflowId,
             executionId,
             resumeIn: response.resumeIn,
+            params,
           });
           break;
       }
@@ -62,13 +64,15 @@ export class WorkflowRunner<
     executionId: string;
     workflow: WorkflowGenerator<T>;
     logger: Logger;
+    params?: any;
   }): Promise<WorkflowResult<T> | WorkflowDelay> {
-    const { executionId, workflow, logger } = params;
+    const { executionId, workflow, logger, params: workflowParams } = params;
 
     const workflowIterator = workflow({
       heapClient: this.heapClient,
       executionId,
       logger,
+      params: workflowParams,
     });
 
     const iteratorResult = await workflowIterator.next();

--- a/packages/core/src/lib/workflow-runner.ts
+++ b/packages/core/src/lib/workflow-runner.ts
@@ -27,11 +27,10 @@ export class WorkflowRunner<
   }
 
   run: EventProcessor<any, any> = async (event, logger) => {
-    const { workflowId, executionId, params } = event;
-    const workflow = this.router[workflowId];
+    const workflow = this.router[event.workflowId];
 
     if (!workflow) {
-      throw new Error(`No workflow registered for "${workflowId}"`);
+      throw new Error(`No workflow registered for "${event.workflowId}"`);
     }
 
     try {
@@ -46,10 +45,7 @@ export class WorkflowRunner<
           return response;
 
         case "workflow-delay":
-          this.schedulerClient.requestWakeUp(
-            { workflowId, executionId, params },
-            response.resumeIn
-          );
+          this.schedulerClient.requestWakeUp(event, response.resumeIn);
           break;
       }
     } catch (err) {

--- a/packages/core/src/lib/workflow-runner.ts
+++ b/packages/core/src/lib/workflow-runner.ts
@@ -3,13 +3,13 @@ import type {
   WorkflowGenerator,
   HeapClient,
   SchedulerClient,
-  TaskProcessor,
+  EventProcessor,
   ExecutionEvent,
 } from "..";
 import { StepDelay, WorkflowDelay, WorkflowResult } from "..";
 
 export class WorkflowRunner<
-  Router extends Record<string, WorkflowGenerator<any>>
+  Router extends Record<string, WorkflowGenerator<any, any>>
 > {
   private heapClient: HeapClient;
   private schedulerClient: SchedulerClient;
@@ -26,7 +26,7 @@ export class WorkflowRunner<
     this.router = params.router;
   }
 
-  run: TaskProcessor = async (event, logger) => {
+  run: EventProcessor<any, any> = async (event, logger) => {
     const { workflowId, executionId, params } = event;
     const workflow = this.router[workflowId];
 
@@ -58,18 +58,16 @@ export class WorkflowRunner<
     }
   };
 
-  private async runWorkflows<T>(params: {
-    workflow: WorkflowGenerator<T>;
-    event: ExecutionEvent;
+  private async runWorkflows<EventParams, Result>(params: {
+    workflow: WorkflowGenerator<EventParams, Result>;
+    event: ExecutionEvent<EventParams>;
     logger: Logger;
-  }): Promise<WorkflowResult<T> | WorkflowDelay> {
+  }): Promise<WorkflowResult<Result> | WorkflowDelay> {
     const { workflow, event, logger } = params;
 
     const workflowIterator = workflow({
+      event,
       heapClient: this.heapClient,
-      workflowId: event.workflowId,
-      executionId: event.executionId,
-      params: event.params,
       logger,
     });
 
@@ -77,7 +75,7 @@ export class WorkflowRunner<
     const stageResponse = iteratorResult.value;
 
     if (iteratorResult.done) {
-      return stageResponse as WorkflowResult<T>;
+      return stageResponse as WorkflowResult<Result>;
     }
 
     if (stageResponse instanceof StepDelay) {

--- a/packages/core/src/lib/workflow-runner.ts
+++ b/packages/core/src/lib/workflow-runner.ts
@@ -4,6 +4,7 @@ import type {
   HeapClient,
   SchedulerClient,
   TaskProcessor,
+  ExecutionEvent,
 } from "..";
 import { StepDelay, WorkflowDelay, WorkflowResult } from "..";
 
@@ -25,8 +26,8 @@ export class WorkflowRunner<
     this.router = params.router;
   }
 
-  run: TaskProcessor = async (task, logger) => {
-    const { workflowId, executionId, params } = task;
+  run: TaskProcessor = async (event, logger) => {
+    const { workflowId, executionId, params } = event;
     const workflow = this.router[workflowId];
 
     if (!workflow) {
@@ -35,10 +36,9 @@ export class WorkflowRunner<
 
     try {
       const response = await this.runWorkflows({
-        executionId,
         workflow,
         logger,
-        params,
+        event,
       });
 
       switch (response.type) {
@@ -46,12 +46,10 @@ export class WorkflowRunner<
           return response;
 
         case "workflow-delay":
-          this.schedulerClient.requestWakeUp({
-            workflowId,
-            executionId,
-            resumeIn: response.resumeIn,
-            params,
-          });
+          this.schedulerClient.requestWakeUp(
+            { workflowId, executionId, params },
+            response.resumeIn
+          );
           break;
       }
     } catch (err) {
@@ -61,18 +59,18 @@ export class WorkflowRunner<
   };
 
   private async runWorkflows<T>(params: {
-    executionId: string;
     workflow: WorkflowGenerator<T>;
+    event: ExecutionEvent;
     logger: Logger;
-    params?: any;
   }): Promise<WorkflowResult<T> | WorkflowDelay> {
-    const { executionId, workflow, logger, params: workflowParams } = params;
+    const { workflow, event, logger } = params;
 
     const workflowIterator = workflow({
       heapClient: this.heapClient,
-      executionId,
+      workflowId: event.workflowId,
+      executionId: event.executionId,
+      params: event.params,
       logger,
-      params: workflowParams,
     });
 
     const iteratorResult = await workflowIterator.next();

--- a/packages/test-invoker/src/test-invoker.ts
+++ b/packages/test-invoker/src/test-invoker.ts
@@ -1,5 +1,9 @@
 import type { Logger } from "pino";
-import type { Task, WorkflowInvoker, WorkflowRunner } from "@yieldstar/core";
+import type {
+  ExecutionEvent,
+  WorkflowInvoker,
+  WorkflowRunner,
+} from "@yieldstar/core";
 import { EventEmitter } from "node:events";
 
 export function createWorkflowInvoker(params: {
@@ -10,7 +14,7 @@ export function createWorkflowInvoker(params: {
   const { logger, runner } = params;
   return {
     workflowEndEmitter,
-    async execute(task: Task) {
+    async execute(task: ExecutionEvent) {
       const { executionId } = task;
       logger.info({ executionId }, "Starting workflow exeuction");
       try {

--- a/packages/test-invoker/src/test-invoker.ts
+++ b/packages/test-invoker/src/test-invoker.ts
@@ -14,15 +14,15 @@ export function createWorkflowInvoker(params: {
   const { logger, runner } = params;
   return {
     workflowEndEmitter,
-    async execute(task: ExecutionEvent) {
-      const { executionId } = task;
+    async execute(event: ExecutionEvent) {
+      const { executionId } = event;
       logger.info({ executionId }, "Starting workflow exeuction");
       try {
-        const response = await runner.run(task, logger);
+        const response = await runner.run(event, logger);
         if (response) {
           workflowEndEmitter.emit(executionId, response.result);
         }
-      } catch (err) {
+      } catch (err: any) {
         logger.error(err);
         workflowEndEmitter.emit(executionId, err);
       }

--- a/packages/test-runtime/src/memory-event-loop.ts
+++ b/packages/test-runtime/src/memory-event-loop.ts
@@ -24,15 +24,15 @@ export class MemoryEventLoop {
     this.isRunning = false;
   }
 
-  private async loop(processTask: EventProcessor) {
+  private async loop(processEvent: EventProcessor) {
     if (!this.isRunning) return;
     while (!this.taskQueue.isEmpty) {
       const task = this.taskQueue.process();
       if (task) {
-        await processTask(task, this.logger);
+        await processEvent(task.event, this.logger);
         this.taskQueue.remove(task.taskId);
       }
     }
-    setTimeout(() => this.loop(processTask), 0);
+    setTimeout(() => this.loop(processEvent), 0);
   }
 }

--- a/packages/test-runtime/src/memory-event-loop.ts
+++ b/packages/test-runtime/src/memory-event-loop.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { TaskProcessor } from "@yieldstar/core";
+import type { EventProcessor } from "@yieldstar/core";
 import { MemoryTaskQueue } from "./memory-task-queue";
 import { MemoryTimers } from "./memory-timers";
 
@@ -15,16 +15,16 @@ export class MemoryEventLoop {
     this.logger = logger;
   }
 
-  start(params: { onNewTask: TaskProcessor }) {
+  start(params: { onNewEvent: EventProcessor }) {
     this.isRunning = true;
-    this.loop(params.onNewTask);
+    this.loop(params.onNewEvent);
   }
 
   stop() {
     this.isRunning = false;
   }
 
-  private async loop(processTask: TaskProcessor) {
+  private async loop(processTask: EventProcessor) {
     if (!this.isRunning) return;
     while (!this.taskQueue.isEmpty) {
       const task = this.taskQueue.process();

--- a/packages/test-runtime/src/memory-event-loop.ts
+++ b/packages/test-runtime/src/memory-event-loop.ts
@@ -24,6 +24,11 @@ export class MemoryEventLoop {
     this.isRunning = false;
   }
 
+  reset() {
+    this.taskQueue.clear();
+    this.timers.clear();
+  }
+
   private async loop(processEvent: EventProcessor) {
     if (!this.isRunning) return;
     while (!this.taskQueue.isEmpty) {

--- a/packages/test-runtime/src/memory-scheduler.ts
+++ b/packages/test-runtime/src/memory-scheduler.ts
@@ -1,4 +1,4 @@
-import type { SchedulerClient } from "@yieldstar/core";
+import type { ExecutionEvent, SchedulerClient } from "@yieldstar/core";
 import type { MemoryTaskQueue } from "./memory-task-queue";
 import type { MemoryTimers } from "./memory-timers";
 import type { MemoryEventLoop } from "./memory-event-loop";
@@ -12,10 +12,7 @@ export class MemorySchedulerClient implements SchedulerClient {
     this.timers = eventLoop.timers;
   }
 
-  async requestWakeUp(
-    event: { workflowId: string; executionId: string; params?: any },
-    resumeIn?: number
-  ) {
+  async requestWakeUp(event: ExecutionEvent, resumeIn?: number) {
     if (!resumeIn) {
       this.taskQueue.add(event);
       return;

--- a/packages/test-runtime/src/memory-scheduler.ts
+++ b/packages/test-runtime/src/memory-scheduler.ts
@@ -16,6 +16,7 @@ export class MemorySchedulerClient implements SchedulerClient {
     workflowId: string;
     executionId: string;
     resumeIn?: number;
+    params?: any;
   }) {
     const { resumeIn, ...task } = params;
     if (!resumeIn) {
@@ -26,6 +27,7 @@ export class MemorySchedulerClient implements SchedulerClient {
       duration: resumeIn,
       workflowId: params.workflowId,
       executionId: params.executionId,
+      params: params.params,
     });
   }
 }

--- a/packages/test-runtime/src/memory-scheduler.ts
+++ b/packages/test-runtime/src/memory-scheduler.ts
@@ -12,22 +12,14 @@ export class MemorySchedulerClient implements SchedulerClient {
     this.timers = eventLoop.timers;
   }
 
-  async requestWakeUp(params: {
-    workflowId: string;
-    executionId: string;
-    resumeIn?: number;
-    params?: any;
-  }) {
-    const { resumeIn, ...task } = params;
+  async requestWakeUp(
+    event: { workflowId: string; executionId: string; params?: any },
+    resumeIn?: number
+  ) {
     if (!resumeIn) {
-      this.taskQueue.add(task);
+      this.taskQueue.add(event);
       return;
     }
-    this.timers.startTimer({
-      duration: resumeIn,
-      workflowId: params.workflowId,
-      executionId: params.executionId,
-      params: params.params,
-    });
+    this.timers.startTimer(event, resumeIn);
   }
 }

--- a/packages/test-runtime/src/memory-task-queue.ts
+++ b/packages/test-runtime/src/memory-task-queue.ts
@@ -41,6 +41,10 @@ export class MemoryTaskQueue {
     }
   }
 
+  clear() {
+    this.queue = [];
+  }
+
   private get visibleQueue() {
     return this.queue.filter((t) => t.visibleFrom < Date.now());
   }

--- a/packages/test-runtime/src/memory-task-queue.ts
+++ b/packages/test-runtime/src/memory-task-queue.ts
@@ -2,18 +2,21 @@ import type { ExecutionEvent } from "@yieldstar/core";
 
 const VISIBILITY_WINDOW = 300000;
 
+type Task = {
+  event: ExecutionEvent;
+  taskId: number;
+  visibleFrom: number;
+};
+
 export class MemoryTaskQueue {
-  private queue: (ExecutionEvent & {
-    taskId: number;
-    visibleFrom: number;
-  })[] = [];
+  private queue: Task[] = [];
   private nextTaskId: number = 0;
 
-  add(task: ExecutionEvent) {
+  add(event: ExecutionEvent) {
     this.queue.push({
       taskId: this.nextTaskId++,
       visibleFrom: Date.now(),
-      ...task,
+      event,
     });
   }
 
@@ -24,7 +27,6 @@ export class MemoryTaskQueue {
     if (!task) return undefined;
 
     task.visibleFrom = now + VISIBILITY_WINDOW;
-
     return task;
   }
 

--- a/packages/test-runtime/src/memory-task-queue.ts
+++ b/packages/test-runtime/src/memory-task-queue.ts
@@ -1,12 +1,15 @@
-import type { Task } from "@yieldstar/core";
+import type { ExecutionEvent } from "@yieldstar/core";
 
 const VISIBILITY_WINDOW = 300000;
 
 export class MemoryTaskQueue {
-  private queue: (Task & { taskId: number; visibleFrom: number })[] = [];
+  private queue: (ExecutionEvent & {
+    taskId: number;
+    visibleFrom: number;
+  })[] = [];
   private nextTaskId: number = 0;
 
-  add(task: Task) {
+  add(task: ExecutionEvent) {
     this.queue.push({
       taskId: this.nextTaskId++,
       visibleFrom: Date.now(),

--- a/packages/test-runtime/src/memory-timers.ts
+++ b/packages/test-runtime/src/memory-timers.ts
@@ -13,6 +13,7 @@ export class MemoryTimers {
     duration: number;
     workflowId: string;
     executionId: string;
+    params?: any;
   }) {
     const { duration, ...task } = params;
     const timer = setTimeout(() => {

--- a/packages/test-runtime/src/memory-timers.ts
+++ b/packages/test-runtime/src/memory-timers.ts
@@ -9,17 +9,15 @@ export class MemoryTimers {
     this.timers = new Set();
   }
 
-  startTimer(params: {
-    duration: number;
-    workflowId: string;
-    executionId: string;
-    params?: any;
-  }) {
-    const { duration, ...task } = params;
+  startTimer(
+    event: { workflowId: string; executionId: string; params?: any },
+    duration: number
+  ) {
     const timer = setTimeout(() => {
-      this.taskQueue.add(task);
+      this.taskQueue.add(event);
       this.timers.delete(timer);
     }, duration);
+
     this.timers.add(timer);
   }
 

--- a/packages/test-runtime/src/memory-timers.ts
+++ b/packages/test-runtime/src/memory-timers.ts
@@ -22,4 +22,8 @@ export class MemoryTimers {
   get isEmpty(): boolean {
     return this.timers.size === 0;
   }
+
+  clear() {
+    this.timers.clear();
+  }
 }

--- a/packages/test-runtime/src/memory-timers.ts
+++ b/packages/test-runtime/src/memory-timers.ts
@@ -1,3 +1,4 @@
+import type { ExecutionEvent } from "@yieldstar/core";
 import type { MemoryTaskQueue } from "./memory-task-queue";
 
 export class MemoryTimers {
@@ -9,10 +10,7 @@ export class MemoryTimers {
     this.timers = new Set();
   }
 
-  startTimer(
-    event: { workflowId: string; executionId: string; params?: any },
-    duration: number
-  ) {
+  startTimer(event: ExecutionEvent, duration: number) {
     const timer = setTimeout(() => {
       this.taskQueue.add(event);
       this.timers.delete(timer);

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,1 +1,1 @@
-export { createWorkflowTestRunner } from "./workflow-runner";
+export { createTestSdkFactory } from "./workflow-runner";

--- a/packages/test-utils/src/workflow-runner.ts
+++ b/packages/test-utils/src/workflow-runner.ts
@@ -14,7 +14,10 @@ export function createWorkflowTestRunner(params?: { logger?: Logger }) {
   const logger = params?.logger ?? pino({ level: "error" });
 
   return {
-    async triggerAndWait<T>(workflow: WorkflowGenerator<T>): Promise<T> {
+    async triggerAndWait<T>(
+      workflow: WorkflowGenerator<T>,
+      options?: { params?: any }
+    ): Promise<T> {
       const workflowRouter = { workflow };
       const memoryEventLoop = new MemoryEventLoop(logger);
 
@@ -33,7 +36,9 @@ export function createWorkflowTestRunner(params?: { logger?: Logger }) {
       memoryEventLoop.start({ onNewTask: invoker.execute });
 
       const sdk = createLocalSdk<typeof workflowRouter>(invoker);
-      const result = await sdk.triggerAndWait("workflow");
+      const result = await sdk.triggerAndWait("workflow", {
+        workflowParams: options?.params,
+      });
 
       memoryEventLoop.stop();
       return result;

--- a/packages/test-utils/src/workflow-runner.ts
+++ b/packages/test-utils/src/workflow-runner.ts
@@ -1,8 +1,8 @@
 import type {
-  WorkflowGenerator,
+  WorkflowRouter,
   TriggerEvent,
   WorkflowGeneratorReturnType,
-  EventParamsOfWorkflow,
+  EventParamsOf,
 } from "@yieldstar/core";
 import type { Logger } from "pino";
 import pino from "pino";
@@ -15,37 +15,39 @@ import {
 } from "@yieldstar/test-runtime";
 import { createLocalSdk } from "yieldstar";
 
-export function createWorkflowTestRunner(params?: { logger?: Logger }) {
+export function createTestSdkFactory(params?: { logger?: Logger }) {
   const logger = params?.logger ?? pino({ level: "error" });
 
-  return {
-    async triggerAndWait<Workflow extends WorkflowGenerator<any, any>>(
-      workflow: Workflow,
-      event?: TriggerEvent<EventParamsOfWorkflow<Workflow>>
-    ): Promise<WorkflowGeneratorReturnType<Workflow>> {
-      const workflowRouter = { workflow };
-      const memoryEventLoop = new MemoryEventLoop(logger);
+  return <W extends WorkflowRouter>(workflowRouter: W) => {
+    const memoryEventLoop = new MemoryEventLoop(logger);
 
-      const workflowRunner = new WorkflowRunner({
-        heapClient: new MemoryHeapClient(),
-        schedulerClient: new MemorySchedulerClient(memoryEventLoop),
-        router: workflowRouter,
-        logger,
-      });
+    const workflowRunner = new WorkflowRunner({
+      heapClient: new MemoryHeapClient(),
+      schedulerClient: new MemorySchedulerClient(memoryEventLoop),
+      router: workflowRouter,
+      logger,
+    });
 
-      const invoker = createWorkflowInvoker({
-        runner: workflowRunner,
-        logger,
-      });
+    const invoker = createWorkflowInvoker({
+      runner: workflowRunner,
+      logger,
+    });
 
+    return async <
+      K extends keyof W & string,
+      EventParams = EventParamsOf<W[K]>
+    >(
+      event: TriggerEvent<"workflow", EventParams>
+    ): Promise<WorkflowGeneratorReturnType<W["workflow"]>> => {
       memoryEventLoop.start({ onNewEvent: invoker.execute });
 
       const sdk = createLocalSdk<typeof workflowRouter>(invoker);
-      const result = await sdk.triggerAndWait("workflow", event);
+      const result = await sdk.triggerAndWait(event);
 
       memoryEventLoop.stop();
+      memoryEventLoop.reset();
 
       return result;
-    },
+    };
   };
 }

--- a/packages/test-utils/src/workflow-runner.ts
+++ b/packages/test-utils/src/workflow-runner.ts
@@ -2,6 +2,7 @@ import type {
   WorkflowGenerator,
   TriggerEvent,
   WorkflowGeneratorReturnType,
+  EventParamsOfWorkflow,
 } from "@yieldstar/core";
 import type { Logger } from "pino";
 import pino from "pino";
@@ -14,13 +15,13 @@ import {
 } from "@yieldstar/test-runtime";
 import { createLocalSdk } from "yieldstar";
 
-export function createWorkflowTestRunner(opts?: { logger?: Logger }) {
-  const logger = opts?.logger ?? pino({ level: "error" });
+export function createWorkflowTestRunner(params?: { logger?: Logger }) {
+  const logger = params?.logger ?? pino({ level: "error" });
 
   return {
     async triggerAndWait<Workflow extends WorkflowGenerator<any, any>>(
       workflow: Workflow,
-      event?: TriggerEvent<Parameters<Workflow>[0]>
+      event?: TriggerEvent<EventParamsOfWorkflow<Workflow>>
     ): Promise<WorkflowGeneratorReturnType<Workflow>> {
       const workflowRouter = { workflow };
       const memoryEventLoop = new MemoryEventLoop(logger);

--- a/packages/test-utils/src/workflow-runner.ts
+++ b/packages/test-utils/src/workflow-runner.ts
@@ -1,4 +1,8 @@
-import type { WorkflowGenerator, TriggerEvent } from "@yieldstar/core";
+import type {
+  WorkflowGenerator,
+  TriggerEvent,
+  WorkflowGeneratorReturnType,
+} from "@yieldstar/core";
 import type { Logger } from "pino";
 import pino from "pino";
 import { WorkflowRunner } from "@yieldstar/core";
@@ -14,10 +18,10 @@ export function createWorkflowTestRunner(opts?: { logger?: Logger }) {
   const logger = opts?.logger ?? pino({ level: "error" });
 
   return {
-    async triggerAndWait<T>(
-      workflow: WorkflowGenerator<T>,
-      event?: TriggerEvent
-    ): Promise<T> {
+    async triggerAndWait<Workflow extends WorkflowGenerator<any, any>>(
+      workflow: Workflow,
+      event?: TriggerEvent<Parameters<Workflow>[0]>
+    ): Promise<WorkflowGeneratorReturnType<Workflow>> {
       const workflowRouter = { workflow };
       const memoryEventLoop = new MemoryEventLoop(logger);
 
@@ -33,14 +37,13 @@ export function createWorkflowTestRunner(opts?: { logger?: Logger }) {
         logger,
       });
 
-      memoryEventLoop.start({ onNewTask: invoker.execute });
+      memoryEventLoop.start({ onNewEvent: invoker.execute });
 
       const sdk = createLocalSdk<typeof workflowRouter>(invoker);
-      const result = await sdk.triggerAndWait("workflow", {
-        workflowParams: options?.params,
-      });
+      const result = await sdk.triggerAndWait("workflow", event);
 
       memoryEventLoop.stop();
+
       return result;
     },
   };

--- a/packages/test-utils/src/workflow-runner.ts
+++ b/packages/test-utils/src/workflow-runner.ts
@@ -1,4 +1,4 @@
-import type { WorkflowGenerator } from "@yieldstar/core";
+import type { WorkflowGenerator, TriggerEvent } from "@yieldstar/core";
 import type { Logger } from "pino";
 import pino from "pino";
 import { WorkflowRunner } from "@yieldstar/core";
@@ -10,13 +10,13 @@ import {
 } from "@yieldstar/test-runtime";
 import { createLocalSdk } from "yieldstar";
 
-export function createWorkflowTestRunner(params?: { logger?: Logger }) {
-  const logger = params?.logger ?? pino({ level: "error" });
+export function createWorkflowTestRunner(opts?: { logger?: Logger }) {
+  const logger = opts?.logger ?? pino({ level: "error" });
 
   return {
     async triggerAndWait<T>(
       workflow: WorkflowGenerator<T>,
-      options?: { params?: any }
+      event?: TriggerEvent
     ): Promise<T> {
       const workflowRouter = { workflow };
       const memoryEventLoop = new MemoryEventLoop(logger);

--- a/packages/yieldstar/src/exports/sdk-http.ts
+++ b/packages/yieldstar/src/exports/sdk-http.ts
@@ -1,4 +1,5 @@
 import type {
+  ParamsOfWorkflow,
   WorkflowRouter,
   WorkflowGeneratorReturnType,
   TriggerEvent,
@@ -12,11 +13,7 @@ export function createHttpSdkFactory<W extends WorkflowRouter>() {
     return {
       async trigger<K extends keyof W>(
         workflowId: K,
-        event?: TriggerEvent & {
-          params?: Parameters<W[K]>[0] extends never
-            ? never
-            : Parameters<W[K]>[0];
-        }
+        event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
       ) {
         const { params } = event ?? {};
         const executionId = event?.executionId ?? randomUUID();
@@ -36,11 +33,7 @@ export function createHttpSdkFactory<W extends WorkflowRouter>() {
       },
       async triggerAndWait<K extends keyof W>(
         workflowId: K,
-        event?: TriggerEvent & {
-          params?: Parameters<W[K]>[0] extends never
-            ? never
-            : Parameters<W[K]>[0];
-        }
+        event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
       ) {
         const { params } = event ?? {};
         const executionId = event?.executionId ?? randomUUID();

--- a/packages/yieldstar/src/exports/sdk-http.ts
+++ b/packages/yieldstar/src/exports/sdk-http.ts
@@ -1,30 +1,32 @@
 import type {
-  ParamsOfWorkflow,
+  EventParamsOfWorkflow,
   WorkflowRouter,
   WorkflowGeneratorReturnType,
   TriggerEvent,
+  ExecutionEvent,
 } from "@yieldstar/core";
 import { deserializeError, isErrorLike } from "serialize-error";
 import { randomUUID } from "node:crypto";
 import { errorWithOriginalStack } from "../internal/serialise";
 
 export function createHttpSdkFactory<W extends WorkflowRouter>() {
-  return (opts: { host: string; port: number }) => {
+  return (params: { host: string; port: number }) => {
     return {
       async trigger<K extends keyof W>(
         workflowId: K,
-        event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
+        triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
       ) {
-        const { params } = event ?? {};
-        const executionId = event?.executionId ?? randomUUID();
-        const res = await fetch(`${opts.host}:${opts.port}/trigger`, {
+        const executionEvent: ExecutionEvent = {
+          executionId: triggerEvent?.executionId ?? randomUUID(),
+          workflowId: workflowId as string,
+          params: triggerEvent?.params,
+        };
+
+        const res = await fetch(`${params.host}:${params.port}/trigger`, {
           method: "POST",
-          body: JSON.stringify({
-            executionId,
-            workflowId,
-            params: params,
-          }),
+          body: JSON.stringify(executionEvent),
         });
+
         if (res.ok) {
           return res.json() as Promise<{ executionId: string }>;
         } else {
@@ -33,14 +35,13 @@ export function createHttpSdkFactory<W extends WorkflowRouter>() {
       },
       async triggerAndWait<K extends keyof W>(
         workflowId: K,
-        event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
+        triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
       ) {
-        const { params } = event ?? {};
-        const executionId = event?.executionId ?? randomUUID();
         // todo: add timeout and cancel request
-        await this.trigger(workflowId, { executionId, params });
+        const { executionId } = await this.trigger(workflowId, triggerEvent);
+
         // todo: set up subscription first (maybe just use ws)
-        const result = await fetch(`${opts.host}:${opts.port}/events`, {
+        const result = await fetch(`${params.host}:${params.port}/events`, {
           method: "POST",
           body: JSON.stringify({ executionId }),
         });

--- a/packages/yieldstar/src/exports/sdk-http.ts
+++ b/packages/yieldstar/src/exports/sdk-http.ts
@@ -1,31 +1,31 @@
 import type {
   WorkflowRouter,
   WorkflowGeneratorReturnType,
+  TriggerEvent,
 } from "@yieldstar/core";
 import { deserializeError, isErrorLike } from "serialize-error";
 import { randomUUID } from "node:crypto";
 import { errorWithOriginalStack } from "../internal/serialise";
 
 export function createHttpSdkFactory<W extends WorkflowRouter>() {
-  return (params: { host: string; port: number }) => {
+  return (opts: { host: string; port: number }) => {
     return {
       async trigger<K extends keyof W>(
         workflowId: K,
-        opts?: {
-          executionId?: string;
-          workflowParams?: Parameters<W[K]>[0] extends never
+        event?: TriggerEvent & {
+          params?: Parameters<W[K]>[0] extends never
             ? never
             : Parameters<W[K]>[0];
         }
       ) {
-        const { workflowParams } = opts ?? {};
-        const executionId = opts?.executionId ?? randomUUID();
-        const res = await fetch(`${params.host}:${params.port}/trigger`, {
+        const { params } = event ?? {};
+        const executionId = event?.executionId ?? randomUUID();
+        const res = await fetch(`${opts.host}:${opts.port}/trigger`, {
           method: "POST",
           body: JSON.stringify({
             executionId,
             workflowId,
-            params: workflowParams,
+            params: params,
           }),
         });
         if (res.ok) {
@@ -36,19 +36,18 @@ export function createHttpSdkFactory<W extends WorkflowRouter>() {
       },
       async triggerAndWait<K extends keyof W>(
         workflowId: K,
-        opts?: {
-          executionId?: string;
-          workflowParams?: Parameters<W[K]>[0] extends never
+        event?: TriggerEvent & {
+          params?: Parameters<W[K]>[0] extends never
             ? never
             : Parameters<W[K]>[0];
         }
       ) {
-        const { workflowParams } = opts ?? {};
-        const executionId = opts?.executionId ?? randomUUID();
+        const { params } = event ?? {};
+        const executionId = event?.executionId ?? randomUUID();
         // todo: add timeout and cancel request
-        await this.trigger(workflowId, { executionId, workflowParams });
+        await this.trigger(workflowId, { executionId, params });
         // todo: set up subscription first (maybe just use ws)
-        const result = await fetch(`${params.host}:${params.port}/events`, {
+        const result = await fetch(`${opts.host}:${opts.port}/events`, {
           method: "POST",
           body: JSON.stringify({ executionId }),
         });

--- a/packages/yieldstar/src/exports/sdk-http.ts
+++ b/packages/yieldstar/src/exports/sdk-http.ts
@@ -1,25 +1,24 @@
 import type {
-  EventParamsOfWorkflow,
+  EventParamsOf,
   WorkflowRouter,
   WorkflowGeneratorReturnType,
   TriggerEvent,
   ExecutionEvent,
 } from "@yieldstar/core";
+import { randomUUIDv7 } from "bun";
 import { deserializeError, isErrorLike } from "serialize-error";
-import { randomUUID } from "node:crypto";
 import { errorWithOriginalStack } from "../internal/serialise";
 
 export function createHttpSdkFactory<W extends WorkflowRouter>() {
   return (params: { host: string; port: number }) => {
     return {
-      async trigger<K extends keyof W>(
-        workflowId: K,
-        triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
+      async trigger<K extends string & keyof W>(
+        event: TriggerEvent<K, EventParamsOf<W[K]>>
       ) {
         const executionEvent: ExecutionEvent = {
-          executionId: triggerEvent?.executionId ?? randomUUID(),
-          workflowId: workflowId as string,
-          params: triggerEvent?.params,
+          executionId: event?.executionId ?? randomUUIDv7(),
+          workflowId: event?.workflowId as string,
+          params: event?.params,
         };
 
         const res = await fetch(`${params.host}:${params.port}/trigger`, {
@@ -33,12 +32,11 @@ export function createHttpSdkFactory<W extends WorkflowRouter>() {
           throw res.statusText;
         }
       },
-      async triggerAndWait<K extends keyof W>(
-        workflowId: K,
-        triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
+      async triggerAndWait<K extends string & keyof W>(
+        event: TriggerEvent<K, EventParamsOf<W[K]>>
       ) {
         // todo: add timeout and cancel request
-        const { executionId } = await this.trigger(workflowId, triggerEvent);
+        const { executionId } = await this.trigger(event);
 
         // todo: set up subscription first (maybe just use ws)
         const result = await fetch(`${params.host}:${params.port}/events`, {

--- a/packages/yieldstar/src/exports/sdk-local.ts
+++ b/packages/yieldstar/src/exports/sdk-local.ts
@@ -6,6 +6,7 @@ import type {
 import { randomUUID } from "node:crypto";
 
 export function createLocalSdk<W extends WorkflowRouter>(
+  workflowRouter: W,
   invoker: WorkflowInvoker
 ) {
   return {

--- a/packages/yieldstar/src/exports/sdk-local.ts
+++ b/packages/yieldstar/src/exports/sdk-local.ts
@@ -2,47 +2,32 @@ import type {
   WorkflowRouter,
   WorkflowGeneratorReturnType,
   WorkflowInvoker,
+  TriggerEvent,
 } from "@yieldstar/core";
 import { randomUUID } from "node:crypto";
 
 export function createLocalSdk<W extends WorkflowRouter>(
-  workflowRouter: W,
   invoker: WorkflowInvoker
 ) {
   return {
-    async trigger<K extends keyof W>(
-      workflowId: K,
-      opts?: {
-        executionId?: string;
-        workflowParams?: Parameters<W[K]>[0] extends never
-          ? never
-          : Parameters<W[K]>[0];
-      }
-    ) {
-      const { workflowParams } = opts ?? {};
-      const executionId = opts?.executionId ?? randomUUID();
+    async trigger<K extends keyof W>(workflowId: K, event?: TriggerEvent) {
+      const executionId = event?.executionId ?? randomUUID();
       await invoker.execute({
         executionId,
         workflowId: workflowId as string,
-        params: workflowParams,
+        params: event?.params ?? {},
       });
       return { executionId };
     },
     async triggerAndWait<K extends keyof W>(
       workflowId: K,
-      opts?: {
-        executionId?: string;
-        workflowParams?: Parameters<W[K]>[0] extends never
-          ? never
-          : Parameters<W[K]>[0];
-      }
+      event?: TriggerEvent
     ) {
-      const { workflowParams } = opts ?? {};
-      const executionId = opts?.executionId ?? randomUUID();
+      const executionId = event?.executionId ?? randomUUID();
       const workflowCompletePromise = new Promise((resolve) => {
         invoker.workflowEndEmitter.once(executionId, resolve);
       });
-      await this.trigger(workflowId, { executionId, workflowParams });
+      await this.trigger(workflowId, event);
       return workflowCompletePromise as Promise<
         WorkflowGeneratorReturnType<W[K]>
       >;

--- a/packages/yieldstar/src/exports/sdk-local.ts
+++ b/packages/yieldstar/src/exports/sdk-local.ts
@@ -1,9 +1,10 @@
 import type {
-  ParamsOfWorkflow,
+  EventParamsOfWorkflow,
   WorkflowRouter,
   WorkflowGeneratorReturnType,
   WorkflowInvoker,
   TriggerEvent,
+  ExecutionEvent,
 } from "@yieldstar/core";
 import { randomUUID } from "node:crypto";
 
@@ -13,25 +14,25 @@ export function createLocalSdk<W extends WorkflowRouter>(
   return {
     async trigger<K extends keyof W>(
       workflowId: K,
-      event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
+      triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
     ) {
-      const executionId = event?.executionId ?? randomUUID();
-      await invoker.execute({
-        executionId,
+      const executionEvent: ExecutionEvent = {
+        executionId: triggerEvent?.executionId ?? randomUUID(),
         workflowId: workflowId as string,
-        params: event?.params ?? {},
-      });
-      return { executionId };
+        params: triggerEvent?.params,
+      };
+      await invoker.execute(executionEvent);
+      return { executionId: executionEvent.executionId };
     },
     async triggerAndWait<K extends keyof W>(
       workflowId: K,
-      event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
+      triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
     ) {
-      const executionId = event?.executionId ?? randomUUID();
+      const executionId = triggerEvent?.executionId ?? randomUUID();
       const workflowCompletePromise = new Promise((resolve) => {
         invoker.workflowEndEmitter.once(executionId, resolve);
       });
-      await this.trigger(workflowId, event);
+      await this.trigger(workflowId, { ...triggerEvent, executionId });
       return workflowCompletePromise as Promise<
         WorkflowGeneratorReturnType<W[K]>
       >;

--- a/packages/yieldstar/src/exports/sdk-local.ts
+++ b/packages/yieldstar/src/exports/sdk-local.ts
@@ -1,4 +1,5 @@
 import type {
+  ParamsOfWorkflow,
   WorkflowRouter,
   WorkflowGeneratorReturnType,
   WorkflowInvoker,
@@ -10,7 +11,10 @@ export function createLocalSdk<W extends WorkflowRouter>(
   invoker: WorkflowInvoker
 ) {
   return {
-    async trigger<K extends keyof W>(workflowId: K, event?: TriggerEvent) {
+    async trigger<K extends keyof W>(
+      workflowId: K,
+      event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
+    ) {
       const executionId = event?.executionId ?? randomUUID();
       await invoker.execute({
         executionId,
@@ -21,7 +25,7 @@ export function createLocalSdk<W extends WorkflowRouter>(
     },
     async triggerAndWait<K extends keyof W>(
       workflowId: K,
-      event?: TriggerEvent
+      event?: TriggerEvent<ParamsOfWorkflow<W[K]>>
     ) {
       const executionId = event?.executionId ?? randomUUID();
       const workflowCompletePromise = new Promise((resolve) => {

--- a/packages/yieldstar/src/exports/sdk-local.ts
+++ b/packages/yieldstar/src/exports/sdk-local.ts
@@ -1,38 +1,36 @@
 import type {
-  EventParamsOfWorkflow,
+  EventParamsOf,
   WorkflowRouter,
   WorkflowGeneratorReturnType,
   WorkflowInvoker,
   TriggerEvent,
   ExecutionEvent,
 } from "@yieldstar/core";
-import { randomUUID } from "node:crypto";
+import { randomUUIDv7 } from "bun";
 
 export function createLocalSdk<W extends WorkflowRouter>(
   invoker: WorkflowInvoker
 ) {
   return {
-    async trigger<K extends keyof W>(
-      workflowId: K,
-      triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
+    async trigger<K extends string & keyof W>(
+      event: TriggerEvent<K, EventParamsOf<W[K]>>
     ) {
       const executionEvent: ExecutionEvent = {
-        executionId: triggerEvent?.executionId ?? randomUUID(),
-        workflowId: workflowId as string,
-        params: triggerEvent?.params,
+        executionId: event.executionId ?? randomUUIDv7(),
+        workflowId: event.workflowId,
+        params: event.params,
       };
       await invoker.execute(executionEvent);
       return { executionId: executionEvent.executionId };
     },
-    async triggerAndWait<K extends keyof W>(
-      workflowId: K,
-      triggerEvent?: TriggerEvent<EventParamsOfWorkflow<W[K]>>
+    async triggerAndWait<K extends string & keyof W>(
+      event: TriggerEvent<K, EventParamsOf<W[K]>>
     ) {
-      const executionId = triggerEvent?.executionId ?? randomUUID();
+      const executionId = event.executionId ?? randomUUIDv7();
       const workflowCompletePromise = new Promise((resolve) => {
         invoker.workflowEndEmitter.once(executionId, resolve);
       });
-      await this.trigger(workflowId, { ...triggerEvent, executionId });
+      await this.trigger({ ...event, executionId });
       return workflowCompletePromise as Promise<
         WorkflowGeneratorReturnType<W[K]>
       >;

--- a/packages/yieldstar/src/exports/workflow.ts
+++ b/packages/yieldstar/src/exports/workflow.ts
@@ -20,20 +20,23 @@ import {
 
 export type WorkflowFn<T> = (
   step: StepRunner,
+  event: { params?: any },
   logger: Logger
 ) => AsyncGenerator<any, T>;
 
-export function createWorkflow<T>(
-  workflowFn: WorkflowFn<T>
-): WorkflowGenerator<T> {
+export function workflow<T>(workflowFn: WorkflowFn<T>): WorkflowGenerator<T> {
   /**
    * @description Advances workflow steps, handling any workflow logic, and
    * yielding control to a workflow executor to do async work
    * @yields {StepResponse}
    */
   return async function* workflowGenerator(params) {
-    const { executionId, heapClient, logger } = params;
-    const workflowIterator = workflowFn(stepRunner, logger);
+    const { executionId, heapClient, logger, params: workflowParams } = params;
+    const workflowIterator = workflowFn(
+      stepRunner,
+      { params: workflowParams },
+      logger
+    );
 
     let keylessStepIndex = -1;
     let iteratorResult: IteratorResult<any> | null = null;
@@ -224,4 +227,11 @@ export function createWorkflow<T>(
      */
     throw new Error("Critical error");
   };
+}
+
+// Keep the old function for backward compatibility
+export function createWorkflow<T>(
+  workflowFn: (step: StepRunner, logger: Logger) => AsyncGenerator<any, T>
+): WorkflowGenerator<T> {
+  return workflow((step, event, logger) => workflowFn(step, logger));
 }

--- a/packages/yieldstar/src/exports/workflow.ts
+++ b/packages/yieldstar/src/exports/workflow.ts
@@ -18,23 +18,30 @@ import {
   WorkflowResult,
 } from "@yieldstar/core";
 
-export type WorkflowFn<T> = (
+export type WorkflowFn<Params, Result> = (
   step: StepRunner,
-  event: { params?: any },
+  event: { workflowId: string; executionId: string; params?: Params },
   logger: Logger
-) => AsyncGenerator<any, T>;
+) => AsyncGenerator<any, Result>;
 
-export function workflow<T>(workflowFn: WorkflowFn<T>): WorkflowGenerator<T> {
+export function workflow<Params, Result>(
+  workflowFn: WorkflowFn<Params, Result>
+): WorkflowGenerator<Result> {
   /**
    * @description Advances workflow steps, handling any workflow logic, and
    * yielding control to a workflow executor to do async work
    * @yields {StepResponse}
    */
-  return async function* workflowGenerator(params) {
-    const { executionId, heapClient, logger, params: workflowParams } = params;
+  return async function* workflowGenerator({
+    workflowId,
+    executionId,
+    heapClient,
+    logger,
+    params,
+  }) {
     const workflowIterator = workflowFn(
       stepRunner,
-      { params: workflowParams },
+      { workflowId, executionId, params },
       logger
     );
 
@@ -229,9 +236,4 @@ export function workflow<T>(workflowFn: WorkflowFn<T>): WorkflowGenerator<T> {
   };
 }
 
-// Keep the old function for backward compatibility
-export function createWorkflow<T>(
-  workflowFn: (step: StepRunner, logger: Logger) => AsyncGenerator<any, T>
-): WorkflowGenerator<T> {
-  return workflow((step, event, logger) => workflowFn(step, logger));
-}
+export const createWorkflow = workflow;

--- a/packages/yieldstar/src/exports/workflow.ts
+++ b/packages/yieldstar/src/exports/workflow.ts
@@ -24,7 +24,7 @@ export type WorkflowFn<EventParams, Result> = (
   logger: Logger
 ) => AsyncGenerator<any, Result>;
 
-export function workflow<EventParams, Result>(
+export function workflow<EventParams = void, Result = void>(
   workflowFn: WorkflowFn<EventParams, Result>
 ): WorkflowGenerator<EventParams, Result> {
   /**

--- a/packages/yieldstar/src/exports/workflow.ts
+++ b/packages/yieldstar/src/exports/workflow.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { WorkflowGenerator } from "@yieldstar/core";
+import type { ExecutionEvent, WorkflowGenerator } from "@yieldstar/core";
 import type { StepRunner } from "../internal/step-runner";
 import { isIterable } from "../internal/utils";
 import {
@@ -18,32 +18,23 @@ import {
   WorkflowResult,
 } from "@yieldstar/core";
 
-export type WorkflowFn<Params, Result> = (
+export type WorkflowFn<EventParams, Result> = (
   step: StepRunner,
-  event: { workflowId: string; executionId: string; params?: Params },
+  event: ExecutionEvent<EventParams>,
   logger: Logger
 ) => AsyncGenerator<any, Result>;
 
-export function workflow<Params, Result>(
-  workflowFn: WorkflowFn<Params, Result>
-): WorkflowGenerator<Result> {
+export function workflow<EventParams, Result>(
+  workflowFn: WorkflowFn<EventParams, Result>
+): WorkflowGenerator<EventParams, Result> {
   /**
    * @description Advances workflow steps, handling any workflow logic, and
    * yielding control to a workflow executor to do async work
    * @yields {StepResponse}
    */
-  return async function* workflowGenerator({
-    workflowId,
-    executionId,
-    heapClient,
-    logger,
-    params,
-  }) {
-    const workflowIterator = workflowFn(
-      stepRunner,
-      { workflowId, executionId, params },
-      logger
-    );
+  return async function* workflowGenerator({ event, heapClient, logger }) {
+    const workflowIterator = workflowFn(stepRunner, event, logger);
+    const { executionId } = event;
 
     let keylessStepIndex = -1;
     let iteratorResult: IteratorResult<any> | null = null;

--- a/packages/yieldstar/src/index.ts
+++ b/packages/yieldstar/src/index.ts
@@ -2,5 +2,5 @@ export { createLocalSdk } from "./exports/sdk-local";
 export { createHttpSdkFactory } from "./exports/sdk-http";
 export { createWorkflowRouter } from "./exports/router";
 export { RetryableError } from "./exports/errors";
-export { createWorkflow } from "./exports/workflow";
+export { createWorkflow, workflow } from "./exports/workflow";
 export type { WorkflowFn } from "./exports/workflow";

--- a/scripts/run-example.ts
+++ b/scripts/run-example.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import inquirer from "inquirer";
 
-const examplesDir = path.resolve(__dirname, "../examples");
+const examplesDir = path.resolve(__dirname, "../examples/workflows");
 
 function listFiles(dir: string): string[] {
   return fs
@@ -23,10 +23,6 @@ async function selectFile(files: string[]): Promise<string> {
   return answer.file;
 }
 
-async function runSelectedFile(filePath: string) {
-  await import(filePath);
-}
-
 async function main() {
   const files = listFiles(examplesDir);
   if (files.length === 0) {
@@ -37,7 +33,8 @@ async function main() {
   const selectedFile = await selectFile(files);
   const selectedFilePath = path.join(examplesDir, selectedFile);
 
-  await runSelectedFile(selectedFilePath);
+  const module = await import(selectedFilePath);
+  console.log(module);
 }
 
 main().catch(console.error);

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -6,17 +6,19 @@ import { createWorkflowTestRunner } from "@yieldstar/test-utils";
 const runner = createWorkflowTestRunner();
 
 test("running sync workflows to completion", async () => {
-  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (step) {
-    let num = yield* step.run(() => {
-      return 1;
-    });
+  const mockWorkflowGenerator = mock<WorkflowFn<undefined, number>>(
+    async function* (step, event, logger) {
+      let num = yield* step.run(() => {
+        return 1;
+      });
 
-    num = yield* step.run(() => {
-      return Promise.resolve(num * 2);
-    });
+      num = yield* step.run(() => {
+        return Promise.resolve(num * 2);
+      });
 
-    return num;
-  });
+      return num;
+    }
+  );
 
   const workflow = createWorkflow(mockWorkflowGenerator);
 

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -1,9 +1,9 @@
 import type { WorkflowFn } from "yieldstar";
 import { expect, test, mock } from "bun:test";
 import { createWorkflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 test("running sync workflows to completion", async () => {
   const mockWorkflowGenerator = mock<WorkflowFn<undefined, number>>(
@@ -21,8 +21,9 @@ test("running sync workflows to completion", async () => {
   );
 
   const workflow = createWorkflow(mockWorkflowGenerator);
+  const sdk = createSdk({ workflow });
 
-  await runner.triggerAndWait(workflow);
+  await sdk({ workflowId: "workflow" });
 
   expect(mockWorkflowGenerator).toBeCalledTimes(1);
 });
@@ -44,7 +45,8 @@ test("deferring workflow execution", async () => {
 
   const workflow = createWorkflow(mockWorkflowGenerator);
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(mockWorkflowGenerator).toBeCalledTimes(2);
 });
@@ -64,7 +66,8 @@ test("resumes workflow after a set delay", async () => {
     return { firstExecutionTime, secondExecutionTime };
   });
 
-  const result = await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  const result = await sdk({ workflowId: "workflow" });
 
   const delay = result.secondExecutionTime - result.firstExecutionTime;
 

--- a/test/cache-keys.test.ts
+++ b/test/cache-keys.test.ts
@@ -1,8 +1,8 @@
 import { expect, test, mock } from "bun:test";
 import { createWorkflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 test("step.run without cache keys", async () => {
   const mock1 = mock(() => 1);
@@ -20,7 +20,8 @@ test("step.run without cache keys", async () => {
     }
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(mock1).toBeCalledTimes(1);
   expect(mock2).not.toBeCalled();
@@ -42,7 +43,8 @@ test("step.run with cache keys", async () => {
     }
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(mock1).toBeCalledTimes(1);
   expect(mock2).toBeCalledTimes(1);
@@ -62,7 +64,8 @@ test("step.delay without cache keys", async () => {
 
   let startTime = Date.now();
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   let duration = Date.now() - startTime;
 
@@ -85,7 +88,8 @@ test("step.delay with cache keys", async () => {
 
   let startTime = Date.now();
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   let duration = Date.now() - startTime;
 
@@ -118,7 +122,8 @@ test("interlacing cache keys and cache indexes", async () => {
     return { stableNum, volatileNum };
   });
 
-  const result = await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  const result = await sdk({ workflowId: "workflow" });
 
   expect(result.stableNum).toBe(2);
   expect(result.volatileNum).toBe(1);

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import { createWorkflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 test("failing steps can be caught", async () => {
   const workflow = createWorkflow(async function* (step) {
@@ -15,7 +15,8 @@ test("failing steps can be caught", async () => {
     }
   });
 
-  const result = await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  const result = await sdk({ workflowId: "workflow" });
 
   expect(result).toBe(true);
 });
@@ -24,5 +25,6 @@ test.skip("errors should be thrown by trigger", async () => {
   const workflow = createWorkflow(async function* (step) {
     throw new Error("Step error");
   });
-  expect(() => runner.triggerAndWait(workflow)).toThrow();
+  const sdk = createSdk({ workflow });
+  expect(() => sdk({ workflowId: "workflow" })).toThrow();
 });

--- a/test/execution.test.ts
+++ b/test/execution.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import { createWorkflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 test("data flow between steps", async () => {
   const workflow = createWorkflow(async function* (step) {
@@ -17,7 +17,8 @@ test("data flow between steps", async () => {
     return num;
   });
 
-  const result = await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  const result = await sdk({ workflowId: "workflow" });
 
   expect(result).toBe(2);
 });
@@ -36,7 +37,8 @@ test("handling async steps", async () => {
     return num;
   });
 
-  const result = await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
 
+  const result = await sdk({ workflowId: "workflow" });
   expect(result).toBe(2);
 });

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -1,0 +1,73 @@
+import type { WorkflowFn } from "yieldstar";
+import { sleep } from "bun";
+import { expect, test, mock } from "bun:test";
+import { workflow } from "yieldstar";
+import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+
+const runner = createWorkflowTestRunner();
+
+test("passing params to a workflow", async () => {
+  const testParams = { foo: "bar", count: 42 };
+  let capturedParams: any;
+
+  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
+    step,
+    event,
+    logger
+  ) {
+    capturedParams = event.params;
+    return yield* step.run(() => event.params);
+  });
+
+  const testWorkflow = workflow(mockWorkflowGenerator);
+  const result = await runner.triggerAndWait(testWorkflow, {
+    params: testParams,
+  });
+
+  await sleep(1);
+
+  expect(result).toBeDefined();
+  expect(mockWorkflowGenerator).toBeCalledTimes(1);
+  expect(capturedParams).toEqual(testParams);
+  expect(result).toEqual(testParams);
+});
+
+test("params are optional", async () => {
+  let capturedParams: any;
+
+  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
+    step,
+    event,
+    logger
+  ) {
+    capturedParams = event.params;
+    return yield* step.run(() => event.params || "default value");
+  });
+
+  const testWorkflow = workflow(mockWorkflowGenerator);
+  const result = await runner.triggerAndWait(testWorkflow);
+
+  await sleep(1);
+
+  expect(result).toBeDefined();
+  expect(mockWorkflowGenerator).toBeCalledTimes(1);
+  expect(capturedParams).toBeUndefined();
+  expect(result).toBe("default value");
+});
+
+test("backward compatibility with createWorkflow", async () => {
+  const testParams = { foo: "bar", count: 42 };
+
+  // Using the old createWorkflow API
+  const oldWorkflow = workflow((step, logger) => {
+    return (async function* () {
+      return yield* step.run(() => "old workflow");
+    })();
+  });
+
+  const result = await runner.triggerAndWait(oldWorkflow, {
+    params: testParams,
+  });
+
+  expect(result).toBe("old workflow");
+});

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -12,7 +12,7 @@ test("passing params to a workflow", async () => {
   let capturedWorkflowId: string = "";
   let capturedExecutionId: string = "";
 
-  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
+  const mockWorkflowGenerator = mock<WorkflowFn<any, any>>(async function* (
     step,
     event
   ) {
@@ -42,13 +42,11 @@ test("params are optional", async () => {
   let capturedWorkflowId: string = "";
   let capturedExecutionId: string = "";
 
-  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
+  const mockWorkflowGenerator = mock<WorkflowFn<any, any>>(async function* (
     step,
     event
   ) {
     capturedParams = event.params;
-    capturedWorkflowId = event.workflowId;
-    capturedExecutionId = event.executionId;
     return yield* step.run(() => event.params || "default value");
   });
 
@@ -60,7 +58,5 @@ test("params are optional", async () => {
   expect(result).toBeDefined();
   expect(mockWorkflowGenerator).toBeCalledTimes(1);
   expect(capturedParams).toBeUndefined();
-  expect(capturedWorkflowId).toBe("workflow");
-  expect(capturedExecutionId).toBeDefined();
   expect(result).toBe("default value");
 });

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -2,45 +2,36 @@ import type { WorkflowFn } from "yieldstar";
 import { sleep } from "bun";
 import { expect, test, mock } from "bun:test";
 import { workflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 test("passing params to a workflow", async () => {
   const testParams = { foo: "bar", count: 42 };
   let capturedParams: any;
-  let capturedWorkflowId: string = "";
-  let capturedExecutionId: string = "";
 
   const mockWorkflowGenerator = mock<WorkflowFn<any, any>>(async function* (
     step,
     event
   ) {
     capturedParams = event.params;
-    capturedWorkflowId = event.workflowId;
-    capturedExecutionId = event.executionId;
     return yield* step.run(() => event.params);
   });
 
   const testWorkflow = workflow(mockWorkflowGenerator);
-  const result = await runner.triggerAndWait(testWorkflow, {
-    params: testParams,
-  });
+  const sdk = createSdk({ workflow: testWorkflow });
+  const result = await sdk({ workflowId: "workflow", params: testParams });
 
   await sleep(1);
 
   expect(result).toBeDefined();
   expect(mockWorkflowGenerator).toBeCalledTimes(1);
   expect(capturedParams).toEqual(testParams);
-  expect(capturedWorkflowId).toBe("workflow");
-  expect(capturedExecutionId).toBeDefined();
   expect(result).toEqual(testParams);
 });
 
 test("params are optional", async () => {
   let capturedParams: any;
-  let capturedWorkflowId: string = "";
-  let capturedExecutionId: string = "";
 
   const mockWorkflowGenerator = mock<WorkflowFn<any, any>>(async function* (
     step,
@@ -51,7 +42,8 @@ test("params are optional", async () => {
   });
 
   const testWorkflow = workflow(mockWorkflowGenerator);
-  const result = await runner.triggerAndWait(testWorkflow);
+  const sdk = createSdk({ workflow: testWorkflow });
+  const result = await sdk({ workflowId: "workflow" });
 
   await sleep(1);
 

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -9,13 +9,16 @@ const runner = createWorkflowTestRunner();
 test("passing params to a workflow", async () => {
   const testParams = { foo: "bar", count: 42 };
   let capturedParams: any;
+  let capturedWorkflowId: string = "";
+  let capturedExecutionId: string = "";
 
   const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
     step,
-    event,
-    logger
+    event
   ) {
     capturedParams = event.params;
+    capturedWorkflowId = event.workflowId;
+    capturedExecutionId = event.executionId;
     return yield* step.run(() => event.params);
   });
 
@@ -29,18 +32,23 @@ test("passing params to a workflow", async () => {
   expect(result).toBeDefined();
   expect(mockWorkflowGenerator).toBeCalledTimes(1);
   expect(capturedParams).toEqual(testParams);
+  expect(capturedWorkflowId).toBe("workflow");
+  expect(capturedExecutionId).toBeDefined();
   expect(result).toEqual(testParams);
 });
 
 test("params are optional", async () => {
   let capturedParams: any;
+  let capturedWorkflowId: string = "";
+  let capturedExecutionId: string = "";
 
   const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
     step,
-    event,
-    logger
+    event
   ) {
     capturedParams = event.params;
+    capturedWorkflowId = event.workflowId;
+    capturedExecutionId = event.executionId;
     return yield* step.run(() => event.params || "default value");
   });
 
@@ -52,22 +60,7 @@ test("params are optional", async () => {
   expect(result).toBeDefined();
   expect(mockWorkflowGenerator).toBeCalledTimes(1);
   expect(capturedParams).toBeUndefined();
+  expect(capturedWorkflowId).toBe("workflow");
+  expect(capturedExecutionId).toBeDefined();
   expect(result).toBe("default value");
-});
-
-test("backward compatibility with createWorkflow", async () => {
-  const testParams = { foo: "bar", count: 42 };
-
-  // Using the old createWorkflow API
-  const oldWorkflow = workflow((step, logger) => {
-    return (async function* () {
-      return yield* step.run(() => "old workflow");
-    })();
-  });
-
-  const result = await runner.triggerAndWait(oldWorkflow, {
-    params: testParams,
-  });
-
-  expect(result).toBe("old workflow");
 });

--- a/test/persistence.test.ts
+++ b/test/persistence.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import { createWorkflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 test("retrieving previous steps from cache", async () => {
   const returnedValues: number[] = [];
@@ -33,7 +33,8 @@ test("retrieving previous steps from cache", async () => {
     return num;
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(returnedValues).toEqual([1, 2]);
   expect(yieldedValues).toEqual([1, 1, 2, 1, 2]);

--- a/test/polling.test.ts
+++ b/test/polling.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import { createWorkflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 test("poll retries when predicate fails", async () => {
   let runs: number = 0;
@@ -16,7 +16,8 @@ test("poll retries when predicate fails", async () => {
     } catch {}
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(runs).toBe(10);
 });
@@ -31,7 +32,8 @@ test("poll resolves when predicate passes", async () => {
     });
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(runs).toBe(1);
 });
@@ -48,7 +50,8 @@ test("poll fails if a regular error is thrown", async () => {
     } catch {}
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(runs).toBe(1);
 });

--- a/test/retries.test.ts
+++ b/test/retries.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import { createWorkflow, RetryableError } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 import { pino } from "pino";
 
 const logger = pino({ level: "fatal" });
-const runner = createWorkflowTestRunner({ logger });
+const createSdk = createTestSdkFactory({ logger });
 
 test("retrying an error for maxAttempts", async () => {
   let runs = 0;
@@ -20,7 +20,8 @@ test("retrying an error for maxAttempts", async () => {
   });
 
   try {
-    await runner.triggerAndWait(workflow);
+    const sdk = createSdk({ workflow });
+    await sdk({ workflowId: "workflow" });
   } catch {
     expect(runs).toEqual(10);
   }
@@ -46,7 +47,8 @@ test("retrying an for maxAttempts (irrespective of number of times error is thro
   });
 
   try {
-    await runner.triggerAndWait(workflow);
+    const sdk = createSdk({ workflow });
+    await sdk({ workflowId: "workflow" });
   } catch {
     expect(runs).toEqual(5);
   }
@@ -76,17 +78,19 @@ test("retrying an for maxAttempts (irrespective of number of number of workflow 
     } catch {}
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
 
   expect(runs).toEqual(6);
 });
 
 test("retrying an error after retry interval", async () => {
   const executions: number[] = [];
+  let start = Date.now();
 
   const workflow = createWorkflow(async function* (step) {
     yield* step.run(async () => {
-      executions.push(Date.now());
+      executions.push((Date.now() - start) / 100);
       if (executions.length > 3) return;
       throw new RetryableError("Step error", {
         maxAttempts: 4,
@@ -95,5 +99,11 @@ test("retrying an error after retry interval", async () => {
     });
   });
 
-  await runner.triggerAndWait(workflow);
+  const sdk = createSdk({ workflow });
+  await sdk({ workflowId: "workflow" });
+
+  expect(executions[0]).toBeCloseTo(0, 1);
+  expect(executions[1]).toBeCloseTo(1, 1);
+  expect(executions[2]).toBeCloseTo(2, 1);
+  expect(executions[3]).toBeCloseTo(3, 1);
 });

--- a/test/trigger.test.ts
+++ b/test/trigger.test.ts
@@ -1,19 +1,23 @@
 import type { WorkflowFn } from "yieldstar";
 import { sleep } from "bun";
 import { expect, test, mock } from "bun:test";
-import { createWorkflow } from "yieldstar";
+import { workflow } from "yieldstar";
 import { createWorkflowTestRunner } from "@yieldstar/test-utils";
 
 const runner = createWorkflowTestRunner();
 
 // todo – use sqlite runtime
 test("triggering a workflow", async () => {
-  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (step) {
+  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
+    step,
+    event,
+    logger
+  ) {
     return yield* step.run(() => 1);
   });
 
-  const workflow = createWorkflow(mockWorkflowGenerator);
-  const result = await runner.triggerAndWait(workflow);
+  const testWorkflow = workflow(mockWorkflowGenerator);
+  const result = await runner.triggerAndWait(testWorkflow);
 
   await sleep(1);
 

--- a/test/trigger.test.ts
+++ b/test/trigger.test.ts
@@ -2,18 +2,21 @@ import type { WorkflowFn } from "yieldstar";
 import { sleep } from "bun";
 import { expect, test, mock } from "bun:test";
 import { workflow } from "yieldstar";
-import { createWorkflowTestRunner } from "@yieldstar/test-utils";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
 
-const runner = createWorkflowTestRunner();
+const createSdk = createTestSdkFactory();
 
 // todo – use sqlite runtime
 test("triggering a workflow", async () => {
-  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (step) {
+  const mockWorkflowGenerator = mock<WorkflowFn<any, any>>(async function* (
+    step
+  ) {
     return yield* step.run(() => 1);
   });
 
   const testWorkflow = workflow(mockWorkflowGenerator);
-  const result = await runner.triggerAndWait(testWorkflow);
+  const sdk = createSdk({ workflow: testWorkflow });
+  const result = await sdk({ workflowId: "workflow" });
 
   await sleep(1);
 

--- a/test/trigger.test.ts
+++ b/test/trigger.test.ts
@@ -8,11 +8,7 @@ const runner = createWorkflowTestRunner();
 
 // todo – use sqlite runtime
 test("triggering a workflow", async () => {
-  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (
-    step,
-    event,
-    logger
-  ) {
+  const mockWorkflowGenerator = mock<WorkflowFn<any>>(async function* (step) {
     return yield* step.run(() => 1);
   });
 


### PR DESCRIPTION
Workflows now receive params in an event object:

```diff
- export const simpleWorkflow = workflow(async function* (step, log) {
+ export const simpleWorkflow = workflow(async function* (step, event, log) {
    const { params } = event;
  }
```

To add types, you need to use generics (later will add validator):

```ts
export const simpleWorkflow = workflow<{ msg: string}, { code: number}>(async function* (step, event, log) {
  console.log(event.params.msg)
  return { code: 0 };
}
```

Params can be passed when triggering a workflow:

```diff
- await sdk.trigger('simple-workflow')
+ await sdk.trigger({ workflowId: 'simple-workflow', params: { msg: 'hello' })
```
