### PR TITLE
event context and http middleware

### DIFF
--- a/examples/http-server/app.ts
+++ b/examples/http-server/app.ts
@@ -8,7 +8,7 @@ try {
   const execution = await sdk.trigger({
     workflowId: "dynamic-workflow",
     params: {
-      msg: "world",
+      msg: "world!",
     },
   });
 

--- a/examples/http-server/server.ts
+++ b/examples/http-server/server.ts
@@ -1,5 +1,8 @@
 import pino from "pino";
-import { createWorkflowHttpServer } from "@yieldstar/bun-http-server";
+import {
+  createMiddleware,
+  createWorkflowHttpServer,
+} from "@yieldstar/bun-http-server";
 import { createWorkflowInvoker } from "@yieldstar/bun-worker-invoker";
 import { sqliteEventLoop } from "./shared";
 
@@ -11,15 +14,28 @@ const invoker = createWorkflowInvoker({
   logger,
 });
 
+const authMiddleware = createMiddleware(async (req, event, next) => {
+  const token = req.headers.get("Authorization");
+  if (!token) {
+    return Response.json("Unauthorized", { status: 401 });
+  }
+  return next();
+});
+
+const corsMiddleware = createMiddleware(async (req, event, next) => {
+  event.context.set("cors", "enabled");
+  const response = await next();
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  response.headers.set("Access-Control-Allow-Headers", "Content-Type");
+  return response;
+});
+
 const server = createWorkflowHttpServer({
   port: 8080,
   logger,
   invoker,
-  responseHeaders: new Headers({
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-  }),
+  middleware: [corsMiddleware, authMiddleware],
 });
 
 sqliteEventLoop.start({ onNewEvent: invoker.execute, logger });

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yieldstar-examples",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "private": true,
   "dependencies": {
     "@yieldstar/bun-http-server": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yieldstar-packages",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/bun-http-server/README.md
+++ b/packages/bun-http-server/README.md
@@ -1,0 +1,155 @@
+# bun-http-server
+
+## Features
+
+- HTTP server for triggering and monitoring workflows
+- Middleware for request/response/context processing
+
+## Installation
+
+```bash
+npm install @yieldstar/bun-http-server
+```
+
+## Usage
+
+### Basic Server
+
+```typescript
+import { createWorkflowHttpServer } from "@yieldstar/bun-http-server";
+import { pino } from "pino";
+
+const logger = pino();
+const invoker = /* your workflow invoker */;
+
+const server = createWorkflowHttpServer({
+  port: 8080,
+  logger,
+  invoker,
+});
+
+const serverInstance = server.serve();
+logger.info(`Server started on port ${serverInstance.port}`);
+```
+
+## Middleware
+
+Middleware can be passed to the server. Middleware supports:
+
+- reading the HTTP request
+- setting context (available to other middleware and the invoked workflow)
+- returning early HTTP responses
+- setting HTTP reponse headers
+
+```typescript
+import {
+  createWorkflowHttpServer,
+  createMiddleware,
+} from "@yieldstar/bun-http-server";
+
+// CORS middleware
+const corsMiddleware = createMiddleware(async (req, event, next) => {
+  // Continue to the next middleware or handler
+  const response = await next();
+
+  // Add CORS headers to the response
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set(
+    "Access-Control-Allow-Methods",
+    "GET, POST, PUT, DELETE, OPTIONS"
+  );
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization"
+  );
+
+  return response;
+});
+
+// Authentication middleware
+const authMiddleware = createMiddleware(async (req, event, next) => {
+  // Get auth token from request
+  const cookies = parseCookies(req.headers.get("Cookie"));
+  const authToken = cookies["X-Token"];
+
+  if (!authToken) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // Store the auth token in the context
+  event.context.set("authToken", authToken);
+
+  // Continue to the next middleware or handler
+  return next();
+});
+
+// Create server with middleware
+const server = createWorkflowHttpServer({
+  port: 8080,
+  logger,
+  invoker,
+  middleware: [corsMiddleware, authMiddleware],
+});
+```
+
+### Middleware lifecycle
+
+```typescript
+import { createMiddleware } from "@yieldstar/bun-http-server";
+
+const myMiddleware = createMiddleware(async (req, event, next) => {
+  // Read the HTTP request
+  const token = req.headers.get("X-token");
+
+  // Read context set by previous middlewares
+  event.context.get("token");
+
+  // Set context
+  if (!token) {
+    event.context.set("token", token);
+  }
+
+  // Advance the middleware chain until either:
+  // A middleware function returns a response,
+  // or, the final handler invokes the workflow
+  const response = await next();
+
+  // At this point context has been delivered to the workflow
+  // so mutating it will throw an error
+  event.context.set("test", "will throw");
+
+  // The response can still be updated before it is sent to the user
+  response.headers.set("X-Handled-By", "SuperAceDev");
+
+  return response;
+});
+```
+
+## API Reference
+
+### `createWorkflowHttpServer(options)`
+
+Creates an HTTP server for YieldStar workflows.
+
+Options:
+
+- `port`: The port to listen on
+- `invoker`: The workflow invoker
+- `logger`: A Pino logger instance
+- `responseHeaders`: Optional headers to add to all responses
+- `middleware`: Optional array of middleware functions
+
+### `createMiddleware(handler)`
+
+Creates a middleware function.
+
+Handler parameters:
+
+- `req`: The request object
+- `event`: The middleware event with a context property (Map)
+- `next`: Function to call the next middleware or handler
+- `logger`: The logger passed to createWorkflowHttpServer
+
+## License
+
+MIT

--- a/packages/bun-http-server/README.md
+++ b/packages/bun-http-server/README.md
@@ -1,4 +1,4 @@
-# bun-http-server
+# @yieldstar/bun-http-server
 
 ## Features
 
@@ -114,9 +114,12 @@ const myMiddleware = createMiddleware(async (req, event, next) => {
   // or, the final handler invokes the workflow
   const response = await next();
 
-  // At this point context has been delivered to the workflow
-  // so mutating it will throw an error
-  event.context.set("test", "will throw");
+  // After next() is called, the context is frozen to prevent modifications
+  // Any attempt to modify the context will throw an error:
+  event.context.set("key", "value"); // Error: Cannot call set on a frozen map
+
+  // When passed to the workflow, the context is converted to a read-only version
+  // that prevents modifications in the workflow
 
   // The response can still be updated before it is sent to the user
   response.headers.set("X-Handled-By", "SuperAceDev");

--- a/packages/bun-http-server/package.json
+++ b/packages/bun-http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldstar/bun-http-server",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/bun-http-server/src/bun-server.ts
+++ b/packages/bun-http-server/src/bun-server.ts
@@ -1,26 +1,25 @@
 import type { Logger } from "pino";
 import type { ExecutionEvent, WorkflowInvoker } from "@yieldstar/core";
 import { serializeError } from "serialize-error";
+import {
+  MiddlewareFunction,
+  MiddlewareEvent,
+  executeMiddlewareChain,
+} from "./middleware";
 
 export function createWorkflowHttpServer(params: {
   port: number;
   invoker: WorkflowInvoker;
   logger: Logger;
-  responseHeaders?: Record<string, string>;
+  middleware?: MiddlewareFunction[];
 }) {
-  const { logger, port, invoker, responseHeaders } = params;
+  const { logger, port, invoker, middleware = [] } = params;
+
   return {
     serve() {
       return Bun.serve({
         port: port,
         async fetch(req) {
-          if (req.method === "OPTIONS") {
-            return new Response(null, {
-              status: 204,
-              headers: responseHeaders,
-            });
-          }
-
           const url = new URL(req.url);
 
           if (url.pathname === "/events") {
@@ -31,7 +30,6 @@ export function createWorkflowHttpServer(params: {
             if (!executionId) {
               return new Response("Missing executionId", {
                 status: 400,
-                headers: responseHeaders,
               });
             }
 
@@ -42,34 +40,42 @@ export function createWorkflowHttpServer(params: {
             if (result instanceof Error) {
               return Response.json(serializeError(result), {
                 status: 500,
-                headers: responseHeaders,
               });
             }
 
-            return Response.json(result, { headers: responseHeaders });
+            return Response.json(result);
           }
 
           if (url.pathname === "/trigger") {
-            try {
-              const event = (await req.json()) as ExecutionEvent;
-              await invoker.execute(event);
-              return Response.json(
-                { executionId: event.executionId },
-                { status: 202, headers: responseHeaders }
-              );
-            } catch (err: any) {
-              logger.error(err);
-              return Response.json(err.message, {
-                status: 400,
-                headers: responseHeaders,
-              });
-            }
+            const executionEvent = (await req.json()) as ExecutionEvent;
+
+            const event = {
+              ...executionEvent,
+              context: new Map(),
+            };
+
+            return executeMiddlewareChain(
+              req,
+              event,
+              logger,
+              middleware,
+              async (req, event) => {
+                try {
+                  console.log("in final handler");
+                  await invoker.execute(event);
+                  return Response.json(
+                    { executionId: event.executionId },
+                    { status: 202 }
+                  );
+                } catch (err: any) {
+                  logger.error(err);
+                  return Response.json(err.message, { status: 400 });
+                }
+              }
+            );
           }
 
-          return new Response("Not Found", {
-            status: 404,
-            headers: responseHeaders,
-          });
+          return new Response("Not Found", { status: 404 });
         },
       });
     },

--- a/packages/bun-http-server/src/bun-server.ts
+++ b/packages/bun-http-server/src/bun-server.ts
@@ -1,13 +1,8 @@
 import type { Logger } from "pino";
-import type {
-  ExecutionEvent,
-  WorkflowInvoker,
-  WorkflowEvent,
-} from "@yieldstar/core";
+import type { ExecutionEvent, WorkflowInvoker } from "@yieldstar/core";
 import { serializeError } from "serialize-error";
 import {
   FreezableMap,
-  ReadOnlyMap,
   MiddlewareEvent,
   MiddlewareFunction,
 } from "@yieldstar/core";
@@ -67,11 +62,7 @@ export function createWorkflowHttpServer(params: {
               middleware,
               async (req, event) => {
                 try {
-                  const workflowEvent: WorkflowEvent = {
-                    ...event,
-                    context: new ReadOnlyMap(event.context),
-                  };
-                  await invoker.execute(workflowEvent);
+                  await invoker.execute(event);
                   return Response.json(
                     { executionId: event.executionId },
                     { status: 202 }

--- a/packages/bun-http-server/src/bun-server.ts
+++ b/packages/bun-http-server/src/bun-server.ts
@@ -1,11 +1,17 @@
 import type { Logger } from "pino";
-import type { ExecutionEvent, WorkflowInvoker } from "@yieldstar/core";
+import type {
+  ExecutionEvent,
+  WorkflowInvoker,
+  WorkflowEvent,
+} from "@yieldstar/core";
 import { serializeError } from "serialize-error";
 import {
-  MiddlewareFunction,
+  FreezableMap,
+  ReadOnlyMap,
   MiddlewareEvent,
-  executeMiddlewareChain,
-} from "./middleware";
+  MiddlewareFunction,
+} from "@yieldstar/core";
+import { executeMiddlewareChain } from "./middleware";
 
 export function createWorkflowHttpServer(params: {
   port: number;
@@ -49,9 +55,9 @@ export function createWorkflowHttpServer(params: {
           if (url.pathname === "/trigger") {
             const executionEvent = (await req.json()) as ExecutionEvent;
 
-            const event = {
+            const event: MiddlewareEvent = {
               ...executionEvent,
-              context: new Map(),
+              context: new FreezableMap<string, any>(),
             };
 
             return executeMiddlewareChain(
@@ -61,8 +67,11 @@ export function createWorkflowHttpServer(params: {
               middleware,
               async (req, event) => {
                 try {
-                  console.log("in final handler");
-                  await invoker.execute(event);
+                  const workflowEvent: WorkflowEvent = {
+                    ...event,
+                    context: new ReadOnlyMap(event.context),
+                  };
+                  await invoker.execute(workflowEvent);
                   return Response.json(
                     { executionId: event.executionId },
                     { status: 202 }

--- a/packages/bun-http-server/src/index.ts
+++ b/packages/bun-http-server/src/index.ts
@@ -1,7 +1,2 @@
 export { createWorkflowHttpServer } from "./bun-server";
 export { createMiddleware } from "./middleware";
-export type {
-  MiddlewareFunction,
-  MiddlewareEvent,
-  MiddlewareNext,
-} from "./middleware";

--- a/packages/bun-http-server/src/index.ts
+++ b/packages/bun-http-server/src/index.ts
@@ -1,1 +1,7 @@
 export { createWorkflowHttpServer } from "./bun-server";
+export { createMiddleware } from "./middleware";
+export type {
+  MiddlewareFunction,
+  MiddlewareEvent,
+  MiddlewareNext,
+} from "./middleware";

--- a/packages/bun-http-server/src/middleware.test.ts
+++ b/packages/bun-http-server/src/middleware.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, expect, it, mock } from "bun:test";
 import pino from "pino";
-import {
-  createMiddleware,
-  executeMiddlewareChain,
-  MiddlewareEvent,
-} from "./middleware";
+import { FreezableMap, MiddlewareEvent } from "@yieldstar/core";
+import { createMiddleware, executeMiddlewareChain } from "./middleware";
 
 const logger = pino();
 
@@ -12,7 +9,7 @@ const reqFixture = new Request("http://localhost");
 const handlerMock = mock(async () => new Response("OK"));
 
 const eventFixture: MiddlewareEvent = {
-  context: new Map(),
+  context: new FreezableMap<string, any>(),
   workflowId: "test",
   executionId: "test",
   params: {},
@@ -20,7 +17,7 @@ const eventFixture: MiddlewareEvent = {
 
 beforeEach(() => {
   handlerMock.mockClear();
-  eventFixture.context = new Map();
+  eventFixture.context = new FreezableMap<string, any>();
 });
 
 it("should create a middleware function", () => {
@@ -42,6 +39,8 @@ it("should execute middleware chain with no middleware", async () => {
 
   expect(handlerMock).toHaveBeenCalledTimes(1);
   expect(await response.text()).toBe("OK");
+  // Context should be frozen after execution
+  expect(eventFixture.context.isFrozen()).toBe(true);
 });
 
 it("should execute middleware chain with one middleware", async () => {
@@ -61,6 +60,8 @@ it("should execute middleware chain with one middleware", async () => {
   expect(handlerMock).toHaveBeenCalledTimes(1);
   expect(eventFixture.context.get("test")).toBe("value");
   expect(await response.text()).toBe("OK");
+  // Context should be frozen after execution
+  expect(eventFixture.context.isFrozen()).toBe(true);
 });
 
 it("should execute middleware chain with multiple middleware", async () => {
@@ -86,6 +87,8 @@ it("should execute middleware chain with multiple middleware", async () => {
   expect(eventFixture.context.get("test1")).toBe("value1");
   expect(eventFixture.context.get("test2")).toBe("value2");
   expect(await response.text()).toBe("OK");
+  // Context should be frozen after execution
+  expect(eventFixture.context.isFrozen()).toBe(true);
 });
 
 it("should short-circuit middleware chain if middleware returns a response", async () => {
@@ -112,6 +115,8 @@ it("should short-circuit middleware chain if middleware returns a response", asy
   expect(eventFixture.context.get("test2")).toBeUndefined();
   expect(await response.text()).toBe("Unauthorized");
   expect(response.status).toBe(401);
+  // Context should not be frozen if the chain is short-circuited
+  expect(eventFixture.context.isFrozen()).toBe(false);
 });
 
 it("should allow middleware to modify the response", async () => {
@@ -131,4 +136,5 @@ it("should allow middleware to modify the response", async () => {
 
   expect(handlerMock).toHaveBeenCalledTimes(1);
   expect(response.headers.get("X-Test")).toBe("test-value");
+  expect(eventFixture.context.isFrozen()).toBe(true);
 });

--- a/packages/bun-http-server/src/middleware.test.ts
+++ b/packages/bun-http-server/src/middleware.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, expect, it, mock } from "bun:test";
+import pino from "pino";
+import {
+  createMiddleware,
+  executeMiddlewareChain,
+  MiddlewareEvent,
+} from "./middleware";
+
+const logger = pino();
+
+const reqFixture = new Request("http://localhost");
+const handlerMock = mock(async () => new Response("OK"));
+
+const eventFixture: MiddlewareEvent = {
+  context: new Map(),
+  workflowId: "test",
+  executionId: "test",
+  params: {},
+};
+
+beforeEach(() => {
+  handlerMock.mockClear();
+  eventFixture.context = new Map();
+});
+
+it("should create a middleware function", () => {
+  const middleware = createMiddleware(async (req, event, next) => {
+    return next();
+  });
+
+  expect(typeof middleware).toBe("function");
+});
+
+it("should execute middleware chain with no middleware", async () => {
+  const response = await executeMiddlewareChain(
+    reqFixture,
+    eventFixture,
+    logger,
+    [],
+    handlerMock
+  );
+
+  expect(handlerMock).toHaveBeenCalledTimes(1);
+  expect(await response.text()).toBe("OK");
+});
+
+it("should execute middleware chain with one middleware", async () => {
+  const middleware = createMiddleware(async (req, event, next) => {
+    event.context.set("test", "value");
+    return next();
+  });
+
+  const response = await executeMiddlewareChain(
+    reqFixture,
+    eventFixture,
+    logger,
+    [middleware],
+    handlerMock
+  );
+
+  expect(handlerMock).toHaveBeenCalledTimes(1);
+  expect(eventFixture.context.get("test")).toBe("value");
+  expect(await response.text()).toBe("OK");
+});
+
+it("should execute middleware chain with multiple middleware", async () => {
+  const middleware1 = createMiddleware(async (req, event, next) => {
+    event.context.set("test1", "value1");
+    return next();
+  });
+
+  const middleware2 = createMiddleware(async (req, event, next) => {
+    event.context.set("test2", "value2");
+    return next();
+  });
+
+  const response = await executeMiddlewareChain(
+    reqFixture,
+    eventFixture,
+    logger,
+    [middleware1, middleware2],
+    handlerMock
+  );
+
+  expect(handlerMock).toHaveBeenCalledTimes(1);
+  expect(eventFixture.context.get("test1")).toBe("value1");
+  expect(eventFixture.context.get("test2")).toBe("value2");
+  expect(await response.text()).toBe("OK");
+});
+
+it("should short-circuit middleware chain if middleware returns a response", async () => {
+  const middleware1 = createMiddleware(async (req, event, next) => {
+    event.context.set("test1", "value1");
+    return new Response("Unauthorized", { status: 401 });
+  });
+
+  const middleware2 = createMiddleware(async (req, event, next) => {
+    event.context.set("test2", "value2");
+    return next();
+  });
+
+  const response = await executeMiddlewareChain(
+    reqFixture,
+    eventFixture,
+    logger,
+    [middleware1, middleware2],
+    handlerMock
+  );
+
+  expect(handlerMock).not.toHaveBeenCalled();
+  expect(eventFixture.context.get("test1")).toBe("value1");
+  expect(eventFixture.context.get("test2")).toBeUndefined();
+  expect(await response.text()).toBe("Unauthorized");
+  expect(response.status).toBe(401);
+});
+
+it("should allow middleware to modify the response", async () => {
+  const middleware = createMiddleware(async (req, event, next) => {
+    const response = await next();
+    response.headers.set("X-Test", "test-value");
+    return response;
+  });
+
+  const response = await executeMiddlewareChain(
+    reqFixture,
+    eventFixture,
+    logger,
+    [middleware],
+    handlerMock
+  );
+
+  expect(handlerMock).toHaveBeenCalledTimes(1);
+  expect(response.headers.get("X-Test")).toBe("test-value");
+});

--- a/packages/bun-http-server/src/middleware.ts
+++ b/packages/bun-http-server/src/middleware.ts
@@ -1,18 +1,5 @@
 import type { Logger } from "pino";
-import type { ExecutionEvent } from "@yieldstar/core";
-
-export type MiddlewareEvent = ExecutionEvent & {
-  context: Map<string, any>;
-};
-
-export type MiddlewareNext = () => Promise<Response>;
-
-export type MiddlewareFunction = (
-  req: Request,
-  event: MiddlewareEvent,
-  next: MiddlewareNext,
-  logger: Logger
-) => Promise<Response>;
+import type { MiddlewareEvent, MiddlewareFunction } from "@yieldstar/core";
 
 /**
  * Creates a middleware function that can be used with the HTTP server.
@@ -43,6 +30,7 @@ export async function executeMiddlewareChain(
   handler: (req: Request, event: MiddlewareEvent) => Promise<Response>
 ): Promise<Response> {
   if (!middlewares.length) {
+    event.context.freeze();
     return handler(req, event);
   }
 
@@ -50,6 +38,7 @@ export async function executeMiddlewareChain(
 
   const next = async (): Promise<Response> => {
     if (index >= middlewares.length) {
+      event.context.freeze();
       return await handler(req, event);
     }
 

--- a/packages/bun-http-server/src/middleware.ts
+++ b/packages/bun-http-server/src/middleware.ts
@@ -1,0 +1,61 @@
+import type { Logger } from "pino";
+import type { ExecutionEvent } from "@yieldstar/core";
+
+export type MiddlewareEvent = ExecutionEvent & {
+  context: Map<string, any>;
+};
+
+export type MiddlewareNext = () => Promise<Response>;
+
+export type MiddlewareFunction = (
+  req: Request,
+  event: MiddlewareEvent,
+  next: MiddlewareNext,
+  logger: Logger
+) => Promise<Response>;
+
+/**
+ * Creates a middleware function that can be used with the HTTP server.
+ *
+ * @param middleware The middleware function to execute
+ * @returns A middleware function
+ */
+export function createMiddleware(
+  middleware: MiddlewareFunction
+): MiddlewareFunction {
+  return middleware;
+}
+
+/**
+ * Executes a chain of middleware functions.
+ *
+ * @param req The request object
+ * @param event The middleware event with context
+ * @param middlewares The array of middleware functions to execute
+ * @param handler The final handler function to execute
+ * @returns A response
+ */
+export async function executeMiddlewareChain(
+  req: Request,
+  event: MiddlewareEvent,
+  logger: Logger,
+  middlewares: MiddlewareFunction[],
+  handler: (req: Request, event: MiddlewareEvent) => Promise<Response>
+): Promise<Response> {
+  if (!middlewares.length) {
+    return handler(req, event);
+  }
+
+  let index = 0;
+
+  const next = async (): Promise<Response> => {
+    if (index >= middlewares.length) {
+      return await handler(req, event);
+    }
+
+    const middleware = middlewares[index++];
+    return middleware(req, event, next, logger);
+  };
+
+  return next();
+}

--- a/packages/bun-sqlite-runtime/package.json
+++ b/packages/bun-sqlite-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldstar/bun-sqlite-runtime",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
+++ b/packages/bun-sqlite-runtime/src/dao/task-queue-dao.ts
@@ -1,11 +1,12 @@
 import { Database } from "bun:sqlite";
-import type { ExecutionEvent } from "@yieldstar/core";
+import type { WorkflowEvent } from "@yieldstar/core";
 
 class TaskRow {
   task_id!: number;
   workflow_id!: string;
   execution_id!: string;
   params?: string;
+  context?: string;
 }
 
 class CountRow {
@@ -26,21 +27,25 @@ export class TaskQueueDao {
         workflow_id TEXT NOT NULL,
         execution_id TEXT NOT NULL,
         params TEXT,
+        context TEXT,
         visible_from INTEGER DEFAULT (strftime('%s', 'now'))
       )
     `);
   }
 
-  insertTask(event: ExecutionEvent) {
+  insertTask(event: WorkflowEvent) {
     const query = this.db.prepare(
-      `INSERT INTO task_queue (workflow_id, execution_id, params)
-      VALUES ($workflowId, $executionId, $params)`
+      `INSERT INTO task_queue (workflow_id, execution_id, params, context)
+      VALUES ($workflowId, $executionId, $params, $context)`
     );
 
     query.run({
       $workflowId: event.workflowId,
       $executionId: event.executionId,
       $params: event.params ? JSON.stringify(event.params) : null,
+      $context: event.context
+        ? JSON.stringify(Array.from(event.context.entries()))
+        : null,
     });
   }
 

--- a/packages/bun-sqlite-runtime/src/dao/timers-dao.ts
+++ b/packages/bun-sqlite-runtime/src/dao/timers-dao.ts
@@ -1,4 +1,4 @@
-import type { ExecutionEvent } from "@yieldstar/core";
+import type { WorkflowEvent } from "@yieldstar/core";
 import { Database } from "bun:sqlite";
 
 class TimerRow {
@@ -8,6 +8,7 @@ class TimerRow {
   execution_id!: string;
   created_at!: number;
   params?: string;
+  context?: string;
 }
 
 class CountRow {
@@ -30,7 +31,8 @@ export class TimersDao {
         workflow_id TEXT NOT NULL,
         execution_id TEXT NOT NULL,
         created_at INTEGER NOT NULL,
-        params TEXT
+        params TEXT,
+        context TEXT
       );
     `);
   }
@@ -38,7 +40,7 @@ export class TimersDao {
   getExpiredTimers(): TimerRow[] {
     const query = this.db
       .query(
-        `SELECT id, delay, workflow_id, execution_id, created_at, params 
+        `SELECT id, delay, workflow_id, execution_id, created_at, params, context
         FROM scheduled_tasks 
         WHERE (created_at + delay) < $currentTime`
       )
@@ -60,10 +62,10 @@ export class TimersDao {
     return count.count;
   }
 
-  insertTimer(event: ExecutionEvent, delay: number) {
+  insertTimer(event: WorkflowEvent, delay: number) {
     const query = this.db.query(
-      `INSERT INTO scheduled_tasks (delay, workflow_id, execution_id, created_at, params) 
-      VALUES ($delay, $workflowId, $executionId, $createdAt, $params)`
+      `INSERT INTO scheduled_tasks (delay, workflow_id, execution_id, created_at, params, context) 
+      VALUES ($delay, $workflowId, $executionId, $createdAt, $params, $context)`
     );
 
     query.run({
@@ -72,6 +74,7 @@ export class TimersDao {
       $executionId: event.executionId,
       $createdAt: Date.now(),
       $params: event.params ? JSON.stringify(event.params) : null,
+      $context: JSON.stringify(Array.from(event.context.entries())),
     });
   }
 

--- a/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-scheduler.ts
@@ -1,4 +1,4 @@
-import type { SchedulerClient, ExecutionEvent } from "@yieldstar/core";
+import type { SchedulerClient, WorkflowEvent } from "@yieldstar/core";
 import { SqliteTaskQueueClient } from "./sqlite-task-queue";
 import { SqliteTimersClient } from "./sqlite-timers";
 
@@ -14,7 +14,7 @@ export class SqliteSchedulerClient implements SchedulerClient {
     this.timersClient = params.timersClient;
   }
 
-  async requestWakeUp(event: ExecutionEvent, resumeIn?: number) {
+  async requestWakeUp(event: WorkflowEvent, resumeIn?: number) {
     if (resumeIn) {
       this.timersClient.createTimer(event, resumeIn);
     } else {

--- a/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
@@ -1,5 +1,5 @@
-import { Database } from "bun:sqlite";
 import type { WorkflowEvent } from "@yieldstar/core";
+import { Database } from "bun:sqlite";
 import { TaskQueueDao } from "./dao/task-queue-dao";
 
 const VISIBILITY_WINDOW = 300000;

--- a/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-task-queue.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import type { ExecutionEvent } from "@yieldstar/core";
+import type { WorkflowEvent } from "@yieldstar/core";
 import { TaskQueueDao } from "./dao/task-queue-dao";
 
 const VISIBILITY_WINDOW = 300000;
@@ -12,7 +12,7 @@ export class SqliteTaskQueue {
     this.taskQueueDao.setupDb();
   }
 
-  add(event: ExecutionEvent) {
+  add(event: WorkflowEvent) {
     this.taskQueueDao.insertTask(event);
   }
 
@@ -33,6 +33,7 @@ export class SqliteTaskQueue {
         workflowId: row.workflow_id,
         executionId: row.execution_id,
         params: row.params ? JSON.parse(row.params) : undefined,
+        context: row.context ? new Map(JSON.parse(row.context)) : new Map(),
       },
     };
   }
@@ -57,7 +58,7 @@ export class SqliteTaskQueueClient {
     this.taskQueueDao = new TaskQueueDao(db);
   }
 
-  add(event: ExecutionEvent) {
+  add(event: WorkflowEvent) {
     this.taskQueueDao.insertTask(event);
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-timers.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-timers.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { TimersDao } from "./dao/timers-dao";
 import { SqliteTaskQueue } from "./sqlite-task-queue";
-import type { ExecutionEvent } from "@yieldstar/core";
+import type { WorkflowEvent } from "@yieldstar/core";
 
 export class SqliteTimers {
   private timersDao: TimersDao;
@@ -20,6 +20,7 @@ export class SqliteTimers {
         workflowId: timer.workflow_id,
         executionId: timer.execution_id,
         params: timer.params ? JSON.parse(timer.params) : undefined,
+        context: timer.context ? new Map(JSON.parse(timer.context)) : new Map(),
       });
     }
   }
@@ -32,7 +33,7 @@ export class SqliteTimersClient {
     this.timersDao = new TimersDao(db);
   }
 
-  createTimer(event: ExecutionEvent, delay: number) {
+  createTimer(event: WorkflowEvent, delay: number) {
     this.timersDao.insertTimer(event, delay);
   }
 }

--- a/packages/bun-sqlite-runtime/src/sqlite-timers.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-timers.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { TimersDao } from "./dao/timers-dao";
 import { SqliteTaskQueue } from "./sqlite-task-queue";
+import { FreezableMap } from "@yieldstar/core";
 import type { WorkflowEvent } from "@yieldstar/core";
 
 export class SqliteTimers {

--- a/packages/bun-worker-invoker/package.json
+++ b/packages/bun-worker-invoker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldstar/bun-worker-invoker",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/bun-worker-invoker/src/bun-worker-invoker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker-invoker.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { ExecutionEvent, WorkflowInvoker } from "@yieldstar/core";
+import type { MiddlewareEvent, WorkflowInvoker } from "@yieldstar/core";
 import { EventEmitter } from "node:events";
 import { fileURLToPath } from "node:url";
 import { deserializeError } from "serialize-error";
@@ -13,7 +13,7 @@ export function createWorkflowInvoker(params: {
   const { logger, workerPath } = params;
   return {
     workflowEndEmitter,
-    async execute<Params>(event: ExecutionEvent<Params>) {
+    async execute(event: MiddlewareEvent) {
       const { executionId } = event;
 
       const filePath = workerPath.startsWith("file:")

--- a/packages/bun-worker-invoker/src/bun-worker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker.ts
@@ -1,5 +1,10 @@
 import type { Logger } from "pino";
-import type { WorkflowEvent, WorkflowRunner } from "@yieldstar/core";
+import type {
+  MiddlewareEvent,
+  WorkflowEvent,
+  WorkflowRunner,
+} from "@yieldstar/core";
+import { ReadOnlyMap } from "@yieldstar/core";
 import { serializeError } from "serialize-error";
 
 export function createWorkflowWorker(
@@ -8,9 +13,13 @@ export function createWorkflowWorker(
 ) {
   return {
     listen() {
-      process.on("message", async (event: WorkflowEvent) => {
+      process.on("message", async (event: MiddlewareEvent) => {
+        const workflowEvent: WorkflowEvent = {
+          ...event,
+          context: new ReadOnlyMap(event.context),
+        };
         try {
-          const response = await workflowRunner.run(event, logger);
+          const response = await workflowRunner.run(workflowEvent, logger);
           process.send!({ status: "completed", response });
         } catch (error: any) {
           process.send!({ status: "error", error: serializeError(error) });

--- a/packages/bun-worker-invoker/src/bun-worker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { ExecutionEvent, WorkflowRunner } from "@yieldstar/core";
+import type { WorkflowEvent, WorkflowRunner } from "@yieldstar/core";
 import { serializeError } from "serialize-error";
 
 export function createWorkflowWorker(
@@ -8,7 +8,7 @@ export function createWorkflowWorker(
 ) {
   return {
     listen() {
-      process.on("message", async (event: ExecutionEvent) => {
+      process.on("message", async (event: WorkflowEvent) => {
         try {
           const response = await workflowRunner.run(event, logger);
           process.send!({ status: "completed", response });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldstar/core",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/base/event.ts
+++ b/packages/core/src/base/event.ts
@@ -21,7 +21,7 @@ export type ExecutionEvent<EventParams = any> = {
 
 export type WorkflowEvent<
   EventParams = any,
-  Context extends Map<any, any> = Map<any, any>
+  Context extends ReadonlyMap<any, any> = ReadonlyMap<any, any>
 > = {
   workflowId: string;
   executionId: string;

--- a/packages/core/src/base/event.ts
+++ b/packages/core/src/base/event.ts
@@ -18,3 +18,13 @@ export type ExecutionEvent<EventParams = any> = {
   executionId: string;
   params: EventParams;
 };
+
+export type WorkflowEvent<
+  EventParams = any,
+  Context extends Map<any, any> = Map<any, any>
+> = {
+  workflowId: string;
+  executionId: string;
+  params: EventParams;
+  context: Context;
+};

--- a/packages/core/src/base/event.ts
+++ b/packages/core/src/base/event.ts
@@ -1,7 +1,13 @@
+import { FreezableMap } from "../utils/map";
+
+export type EventParams = Record<string, any> | void;
+export type EventContext = ReadonlyMap<any, any>;
+export type MiddlewareEventContext = FreezableMap<any, any>;
+
 export type TriggerEvent<
   WorkflowId extends string,
-  EventParams = any
-> = EventParams extends void
+  Params extends EventParams = EventParams
+> = Params extends void
   ? {
       workflowId: WorkflowId;
       executionId?: string;
@@ -10,21 +16,28 @@ export type TriggerEvent<
   : {
       workflowId: WorkflowId;
       executionId?: string;
-      params: EventParams;
+      params: Params;
     };
 
-export type ExecutionEvent<EventParams = any> = {
+export type ExecutionEvent<Params extends EventParams = EventParams> = {
   workflowId: string;
   executionId: string;
-  params: EventParams;
+  params: Params;
 };
 
 export type WorkflowEvent<
-  EventParams = any,
+  Params extends EventParams = EventParams,
   Context extends ReadonlyMap<any, any> = ReadonlyMap<any, any>
 > = {
   workflowId: string;
   executionId: string;
-  params: EventParams;
+  params: Params;
+  context: Context;
+};
+
+export type MiddlewareEvent<
+  Params extends EventParams = EventParams,
+  Context extends MiddlewareEventContext = MiddlewareEventContext
+> = ExecutionEvent<Params> & {
   context: Context;
 };

--- a/packages/core/src/base/invoker.ts
+++ b/packages/core/src/base/invoker.ts
@@ -3,5 +3,5 @@ import type { ExecutionEvent } from "./event";
 
 export type WorkflowInvoker = {
   workflowEndEmitter: EventEmitter;
-  execute<EventParams>(event: ExecutionEvent<EventParams>): Promise<void>;
+  execute(event: ExecutionEvent): Promise<void>;
 };

--- a/packages/core/src/base/middleware.ts
+++ b/packages/core/src/base/middleware.ts
@@ -1,0 +1,16 @@
+import type { Logger } from "pino";
+import { ExecutionEvent } from "./event";
+import { FreezableMap } from "../utils/map";
+
+export type MiddlewareEvent = ExecutionEvent & {
+  context: FreezableMap<string, any>;
+};
+
+export type MiddlewareNext = () => Promise<Response>;
+
+export type MiddlewareFunction = (
+  req: Request,
+  event: MiddlewareEvent,
+  next: MiddlewareNext,
+  logger: Logger
+) => Promise<Response>;

--- a/packages/core/src/base/middleware.ts
+++ b/packages/core/src/base/middleware.ts
@@ -1,10 +1,5 @@
 import type { Logger } from "pino";
-import { ExecutionEvent } from "./event";
-import { FreezableMap } from "../utils/map";
-
-export type MiddlewareEvent = ExecutionEvent & {
-  context: FreezableMap<string, any>;
-};
+import type { MiddlewareEvent } from "./event";
 
 export type MiddlewareNext = () => Promise<Response>;
 

--- a/packages/core/src/base/runtime.ts
+++ b/packages/core/src/base/runtime.ts
@@ -1,8 +1,12 @@
 import type { Logger } from "pino";
 import type { WorkflowResult } from "./step";
-import type { ExecutionEvent } from "./event";
+import type { WorkflowEvent } from "./event";
 
-export type EventProcessor<EventParams = any, Result = any> = (
-  event: ExecutionEvent<EventParams>,
+export type EventProcessor<
+  EventParams = any,
+  Result = any,
+  Context extends Map<any, any> = Map<any, any>
+> = (
+  event: WorkflowEvent<EventParams, Context>,
   logger: Logger
 ) => Promise<void | WorkflowResult<Result>>;

--- a/packages/core/src/base/runtime.ts
+++ b/packages/core/src/base/runtime.ts
@@ -2,11 +2,7 @@ import type { Logger } from "pino";
 import type { WorkflowResult } from "./step";
 import type { WorkflowEvent } from "./event";
 
-export type EventProcessor<
-  EventParams = any,
-  Result = any,
-  Context extends ReadonlyMap<any, any> = ReadonlyMap<any, any>
-> = (
-  event: WorkflowEvent<EventParams, Context>,
+export type EventProcessor = (
+  event: WorkflowEvent,
   logger: Logger
-) => Promise<void | WorkflowResult<Result>>;
+) => Promise<void | WorkflowResult<any>>;

--- a/packages/core/src/base/runtime.ts
+++ b/packages/core/src/base/runtime.ts
@@ -5,7 +5,7 @@ import type { WorkflowEvent } from "./event";
 export type EventProcessor<
   EventParams = any,
   Result = any,
-  Context extends Map<any, any> = Map<any, any>
+  Context extends ReadonlyMap<any, any> = ReadonlyMap<any, any>
 > = (
   event: WorkflowEvent<EventParams, Context>,
   logger: Logger

--- a/packages/core/src/base/scheduler.ts
+++ b/packages/core/src/base/scheduler.ts
@@ -1,8 +1,8 @@
-import type { ExecutionEvent } from "./event";
+import type { WorkflowEvent, EventParams } from "./event";
 
 export interface SchedulerClient {
-  requestWakeUp<EventParams>(
-    event: ExecutionEvent<EventParams>,
+  requestWakeUp<Params extends EventParams>(
+    event: WorkflowEvent<Params>,
     resumeIn?: number
   ): Promise<void>;
 }

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -1,27 +1,27 @@
 import type { Logger } from "pino";
+import type { EventParams, WorkflowEvent, EventContext } from "./event";
 import { HeapClient } from "./heap";
 import { StepResponse, WorkflowResult } from "./step";
-import type { WorkflowEvent } from "./event";
 
 export type WorkflowGeneratorParams<
-  EventParams,
-  Context extends ReadonlyMap<any, any>
+  Params extends EventParams,
+  Context extends EventContext
 > = {
-  event: WorkflowEvent<EventParams, Context>;
+  event: WorkflowEvent<Params, Context>;
   heapClient: HeapClient;
   logger: Logger;
 };
 
 export type WorkflowGenerator<
-  EventParams,
+  Params extends EventParams,
   Result,
-  Context extends Map<any, any>
+  Context extends EventContext
 > = (
-  genParams: WorkflowGeneratorParams<EventParams, Context>
+  genParams: WorkflowGeneratorParams<Params, Context>
 ) => AsyncGenerator<StepResponse, WorkflowResult<Result>, StepResponse>;
 
 export type WorkflowGeneratorReturnType<CG> = CG extends WorkflowGenerator<
-  infer EventParams,
+  infer Params,
   infer Result,
   infer Context
 >

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -1,29 +1,37 @@
 import type { Logger } from "pino";
 import { HeapClient } from "./heap";
 import { StepResponse, WorkflowResult } from "./step";
-import type { ExecutionEvent } from "./event";
+import type { ExecutionEvent, WorkflowEvent } from "./event";
 
-export type WorkflowGeneratorParams<EventParams> = {
-  event: ExecutionEvent<EventParams>;
+export type WorkflowGeneratorParams<
+  EventParams,
+  Context extends Map<any, any>
+> = {
+  event: WorkflowEvent<EventParams, Context>;
   heapClient: HeapClient;
   logger: Logger;
 };
 
-export type WorkflowGenerator<EventParams, Result> = (
-  genParams: WorkflowGeneratorParams<EventParams>
+export type WorkflowGenerator<
+  EventParams,
+  Result,
+  Context extends Map<any, any>
+> = (
+  genParams: WorkflowGeneratorParams<EventParams, Context>
 ) => AsyncGenerator<StepResponse, WorkflowResult<Result>, StepResponse>;
 
 export type WorkflowGeneratorReturnType<CG> = CG extends WorkflowGenerator<
   infer EventParams,
-  infer Result
+  infer Result,
+  infer Context
 >
   ? Result
   : never;
 
-export type WorkflowRouter = Record<string, WorkflowGenerator<any, any>>;
+export type WorkflowRouter = Record<string, WorkflowGenerator<any, any, any>>;
 
-export type EventOfWorkflow<W extends WorkflowGenerator<any, any>> =
+export type EventOfWorkflow<W extends WorkflowGenerator<any, any, any>> =
   Parameters<W>[0]["event"];
 
-export type EventParamsOf<W extends WorkflowGenerator<any, any>> =
+export type EventParamsOf<W extends WorkflowGenerator<any, any, any>> =
   Parameters<W>[0]["event"]["params"];

--- a/packages/core/src/base/workflow.ts
+++ b/packages/core/src/base/workflow.ts
@@ -1,11 +1,11 @@
 import type { Logger } from "pino";
 import { HeapClient } from "./heap";
 import { StepResponse, WorkflowResult } from "./step";
-import type { ExecutionEvent, WorkflowEvent } from "./event";
+import type { WorkflowEvent } from "./event";
 
 export type WorkflowGeneratorParams<
   EventParams,
-  Context extends Map<any, any>
+  Context extends ReadonlyMap<any, any>
 > = {
   event: WorkflowEvent<EventParams, Context>;
   heapClient: HeapClient;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,13 @@ export type { HeapClient, HeapRecord } from "./base/heap";
 export type { WorkflowInvoker } from "./base/invoker";
 export type { EventProcessor } from "./base/runtime";
 export type { SchedulerClient } from "./base/scheduler";
-export type { TriggerEvent, ExecutionEvent, WorkflowEvent } from "./base/event";
+export type { ExecutionEvent, TriggerEvent, WorkflowEvent } from "./base/event";
+
+export type {
+  MiddlewareNext,
+  MiddlewareEvent,
+  MiddlewareFunction,
+} from "./base/middleware";
 
 export type {
   WorkflowGenerator,
@@ -26,3 +32,4 @@ export {
 } from "./base/step";
 
 export { WorkflowRunner } from "./lib/workflow-runner";
+export { ReadOnlyMap, FreezableMap } from "./utils/map";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,13 +2,16 @@ export type { HeapClient, HeapRecord } from "./base/heap";
 export type { WorkflowInvoker } from "./base/invoker";
 export type { EventProcessor } from "./base/runtime";
 export type { SchedulerClient } from "./base/scheduler";
-export type { ExecutionEvent, TriggerEvent, WorkflowEvent } from "./base/event";
-
 export type {
-  MiddlewareNext,
+  EventParams,
+  EventContext,
+  ExecutionEvent,
   MiddlewareEvent,
-  MiddlewareFunction,
-} from "./base/middleware";
+  TriggerEvent,
+  WorkflowEvent,
+} from "./base/event";
+
+export type { MiddlewareNext, MiddlewareFunction } from "./base/middleware";
 
 export type {
   WorkflowGenerator,
@@ -32,4 +35,6 @@ export {
 } from "./base/step";
 
 export { WorkflowRunner } from "./lib/workflow-runner";
+
 export { ReadOnlyMap, FreezableMap } from "./utils/map";
+export { errorWithOriginalStack } from "./utils/error";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,8 @@ export type { HeapClient, HeapRecord } from "./base/heap";
 export type { WorkflowInvoker } from "./base/invoker";
 export type { EventProcessor } from "./base/runtime";
 export type { SchedulerClient } from "./base/scheduler";
+export type { TriggerEvent, ExecutionEvent, WorkflowEvent } from "./base/event";
+
 export type {
   WorkflowGenerator,
   WorkflowGeneratorReturnType,
@@ -9,10 +11,6 @@ export type {
   EventOfWorkflow,
   EventParamsOf,
 } from "./base/workflow";
-export type {
-  TriggerEvent as TriggerEvent,
-  ExecutionEvent as ExecutionEvent,
-} from "./base/event";
 
 export {
   StepCacheCheck,

--- a/packages/core/src/lib/workflow-runner.ts
+++ b/packages/core/src/lib/workflow-runner.ts
@@ -4,12 +4,12 @@ import type {
   HeapClient,
   SchedulerClient,
   EventProcessor,
-  ExecutionEvent,
+  WorkflowEvent,
 } from "..";
 import { StepDelay, WorkflowDelay, WorkflowResult } from "..";
 
 export class WorkflowRunner<
-  Router extends Record<string, WorkflowGenerator<any, any>>
+  Router extends Record<string, WorkflowGenerator<any, any, any>>
 > {
   private heapClient: HeapClient;
   private schedulerClient: SchedulerClient;
@@ -54,9 +54,13 @@ export class WorkflowRunner<
     }
   };
 
-  private async runWorkflows<EventParams, Result>(params: {
-    workflow: WorkflowGenerator<EventParams, Result>;
-    event: ExecutionEvent<EventParams>;
+  private async runWorkflows<
+    EventParams,
+    Result,
+    Context extends Map<any, any>
+  >(params: {
+    workflow: WorkflowGenerator<EventParams, Result, Context>;
+    event: WorkflowEvent<EventParams, Context>;
     logger: Logger;
   }): Promise<WorkflowResult<Result> | WorkflowDelay> {
     const { workflow, event, logger } = params;

--- a/packages/core/src/lib/workflow-runner.ts
+++ b/packages/core/src/lib/workflow-runner.ts
@@ -5,8 +5,10 @@ import type {
   SchedulerClient,
   EventProcessor,
   WorkflowEvent,
+  EventParams,
 } from "..";
 import { StepDelay, WorkflowDelay, WorkflowResult } from "..";
+import { EventContext } from "../base/event";
 
 export class WorkflowRunner<
   Router extends Record<string, WorkflowGenerator<any, any, any>>
@@ -26,7 +28,7 @@ export class WorkflowRunner<
     this.router = params.router;
   }
 
-  run: EventProcessor<any, any> = async (event, logger) => {
+  run: EventProcessor = async (event, logger) => {
     const workflow = this.router[event.workflowId];
 
     if (!workflow) {
@@ -55,12 +57,12 @@ export class WorkflowRunner<
   };
 
   private async runWorkflows<
-    EventParams,
+    Params extends EventParams,
     Result,
-    Context extends Map<any, any>
+    Context extends EventContext
   >(params: {
-    workflow: WorkflowGenerator<EventParams, Result, Context>;
-    event: WorkflowEvent<EventParams, Context>;
+    workflow: WorkflowGenerator<Params, Result, Context>;
+    event: WorkflowEvent<Params, Context>;
     logger: Logger;
   }): Promise<WorkflowResult<Result> | WorkflowDelay> {
     const { workflow, event, logger } = params;

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -1,0 +1,6 @@
+export function errorWithOriginalStack(error: Error, fn: Function) {
+  const err = new Error(error.message);
+  Error.captureStackTrace(err, fn);
+  err.stack = error.stack;
+  throw err;
+}

--- a/packages/core/src/utils/map.test.ts
+++ b/packages/core/src/utils/map.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import { ReadOnlyMap, FreezableMap } from "./map";
+
+test("ReadOnlyMap", () => {
+  const originalMap = new Map<string, any>();
+  originalMap.set("key", "value");
+
+  const readOnlyMap = new ReadOnlyMap(originalMap);
+
+  // Reading should work
+  expect(readOnlyMap.get("key")).toBe("value");
+  expect(readOnlyMap.has("key")).toBe(true);
+  expect(readOnlyMap.size).toBe(1);
+
+  expect("set" in readOnlyMap).toBe(false);
+  expect("delete" in readOnlyMap).toBe(false);
+  expect("clear" in readOnlyMap).toBe(false);
+});
+
+test("FreezableMap", () => {
+  const freezableMap = new FreezableMap<string, any>();
+  freezableMap.set("key", "value");
+
+  // Before freezing, modifications should work
+  expect(freezableMap.get("key")).toBe("value");
+  freezableMap.set("key2", "value2");
+  expect(freezableMap.get("key2")).toBe("value2");
+
+  // Freeze the map
+  freezableMap.freeze();
+  expect(freezableMap.isFrozen()).toBe(true);
+
+  // After freezing, modifications should throw
+  expect(() => freezableMap.set("key3", "value3")).toThrow(
+    "Cannot call set on a frozen map"
+  );
+  expect(() => freezableMap.delete("key")).toThrow(
+    "Cannot call delete on a frozen map"
+  );
+  expect(() => freezableMap.clear()).toThrow(
+    "Cannot call clear on a frozen map"
+  );
+});

--- a/packages/core/src/utils/map.test.ts
+++ b/packages/core/src/utils/map.test.ts
@@ -11,6 +11,11 @@ test("ReadOnlyMap", () => {
   expect(readOnlyMap.get("key")).toBe("value");
   expect(readOnlyMap.has("key")).toBe(true);
   expect(readOnlyMap.size).toBe(1);
+  expect(Array.from(readOnlyMap.entries())).toEqual([["key", "value"]]);
+  expect(Array.from(readOnlyMap.keys())).toEqual(["key"]);
+  expect(Array.from(readOnlyMap.values())).toEqual(["value"]);
+  expect(readOnlyMap.forEach).toBeInstanceOf(Function);
+  expect(readOnlyMap[Symbol.iterator]).toBeInstanceOf(Function);
 
   expect("set" in readOnlyMap).toBe(false);
   expect("delete" in readOnlyMap).toBe(false);

--- a/packages/core/src/utils/map.ts
+++ b/packages/core/src/utils/map.ts
@@ -1,0 +1,75 @@
+export class ReadOnlyMap<K, V> implements ReadonlyMap<K, V> {
+  private sourceMap: Map<K, V>;
+
+  constructor(sourceMap: Map<K, V>) {
+    this.sourceMap = sourceMap;
+  }
+
+  get(key: K): V | undefined {
+    return this.sourceMap.get(key);
+  }
+
+  has(key: K): boolean {
+    return this.sourceMap.has(key);
+  }
+
+  get size(): number {
+    return this.sourceMap.size;
+  }
+
+  entries(): ReturnType<Map<K, V>["entries"]> {
+    return this.sourceMap.entries();
+  }
+
+  keys(): ReturnType<Map<K, V>["keys"]> {
+    return this.sourceMap.keys();
+  }
+
+  values(): ReturnType<Map<K, V>["values"]> {
+    return this.sourceMap.values();
+  }
+
+  forEach(
+    callbackfn: (value: V, key: K, map: Map<K, V>) => void,
+    thisArg?: any
+  ): void {
+    return this.sourceMap.forEach(callbackfn, thisArg);
+  }
+
+  [Symbol.iterator](): ReturnType<Map<K, V>[typeof Symbol.iterator]> {
+    return this.sourceMap[Symbol.iterator]();
+  }
+}
+
+export class FreezableMap<K, V> extends Map<K, V> {
+  private frozen = false;
+
+  freeze(): void {
+    this.frozen = true;
+  }
+
+  isFrozen(): boolean {
+    return this.frozen;
+  }
+
+  set(key: K, value: V): this {
+    if (this.frozen) {
+      throw new Error("Cannot call set on a frozen map");
+    }
+    return super.set(key, value);
+  }
+
+  delete(key: K): boolean {
+    if (this.frozen) {
+      throw new Error("Cannot call delete on a frozen map");
+    }
+    return super.delete(key);
+  }
+
+  clear(): void {
+    if (this.frozen) {
+      throw new Error("Cannot call clear on a frozen map");
+    }
+    return super.clear();
+  }
+}

--- a/packages/core/src/utils/map.ts
+++ b/packages/core/src/utils/map.ts
@@ -1,3 +1,5 @@
+import { errorWithOriginalStack } from "./error";
+
 export class ReadOnlyMap<K, V> implements ReadonlyMap<K, V> {
   private sourceMap: Map<K, V>;
 
@@ -17,15 +19,15 @@ export class ReadOnlyMap<K, V> implements ReadonlyMap<K, V> {
     return this.sourceMap.size;
   }
 
-  entries(): ReturnType<Map<K, V>["entries"]> {
+  entries(): MapIterator<[K, V]> {
     return this.sourceMap.entries();
   }
 
-  keys(): ReturnType<Map<K, V>["keys"]> {
+  keys(): MapIterator<K> {
     return this.sourceMap.keys();
   }
 
-  values(): ReturnType<Map<K, V>["values"]> {
+  values(): MapIterator<V> {
     return this.sourceMap.values();
   }
 
@@ -36,7 +38,7 @@ export class ReadOnlyMap<K, V> implements ReadonlyMap<K, V> {
     return this.sourceMap.forEach(callbackfn, thisArg);
   }
 
-  [Symbol.iterator](): ReturnType<Map<K, V>[typeof Symbol.iterator]> {
+  [Symbol.iterator](): MapIterator<[K, V]> {
     return this.sourceMap[Symbol.iterator]();
   }
 }
@@ -54,21 +56,24 @@ export class FreezableMap<K, V> extends Map<K, V> {
 
   set(key: K, value: V): this {
     if (this.frozen) {
-      throw new Error("Cannot call set on a frozen map");
+      const error = new Error("Cannot call set on a frozen map");
+      throw errorWithOriginalStack(error, this.set);
     }
     return super.set(key, value);
   }
 
   delete(key: K): boolean {
     if (this.frozen) {
-      throw new Error("Cannot call delete on a frozen map");
+      const error = new Error("Cannot call delete on a frozen map");
+      throw errorWithOriginalStack(error, this.delete);
     }
     return super.delete(key);
   }
 
   clear(): void {
     if (this.frozen) {
-      throw new Error("Cannot call clear on a frozen map");
+      const error = new Error("Cannot call clear on a frozen map");
+      throw errorWithOriginalStack(error, this.clear);
     }
     return super.clear();
   }

--- a/packages/test-invoker/package.json
+++ b/packages/test-invoker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldstar/test-invoker",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/test-invoker/src/test-invoker.ts
+++ b/packages/test-invoker/src/test-invoker.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "pino";
 import type {
-  ExecutionEvent,
+  WorkflowEvent,
   WorkflowInvoker,
   WorkflowRunner,
 } from "@yieldstar/core";
@@ -14,7 +14,7 @@ export function createWorkflowInvoker(params: {
   const { logger, runner } = params;
   return {
     workflowEndEmitter,
-    async execute(event: ExecutionEvent) {
+    async execute(event: WorkflowEvent) {
       const { executionId } = event;
       logger.info({ executionId }, "Starting workflow exeuction");
       try {

--- a/packages/test-runtime/package.json
+++ b/packages/test-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldstar/test-runtime",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/test-runtime/src/memory-scheduler.ts
+++ b/packages/test-runtime/src/memory-scheduler.ts
@@ -1,4 +1,4 @@
-import type { ExecutionEvent, SchedulerClient } from "@yieldstar/core";
+import type { WorkflowEvent, SchedulerClient } from "@yieldstar/core";
 import type { MemoryTaskQueue } from "./memory-task-queue";
 import type { MemoryTimers } from "./memory-timers";
 import type { MemoryEventLoop } from "./memory-event-loop";
@@ -12,7 +12,7 @@ export class MemorySchedulerClient implements SchedulerClient {
     this.timers = eventLoop.timers;
   }
 
-  async requestWakeUp(event: ExecutionEvent, resumeIn?: number) {
+  async requestWakeUp(event: WorkflowEvent, resumeIn?: number) {
     if (!resumeIn) {
       this.taskQueue.add(event);
       return;

--- a/packages/test-runtime/src/memory-task-queue.ts
+++ b/packages/test-runtime/src/memory-task-queue.ts
@@ -1,9 +1,9 @@
-import type { ExecutionEvent } from "@yieldstar/core";
+import type { WorkflowEvent } from "@yieldstar/core";
 
 const VISIBILITY_WINDOW = 300000;
 
 type Task = {
-  event: ExecutionEvent;
+  event: WorkflowEvent;
   taskId: number;
   visibleFrom: number;
 };
@@ -12,7 +12,7 @@ export class MemoryTaskQueue {
   private queue: Task[] = [];
   private nextTaskId: number = 0;
 
-  add(event: ExecutionEvent) {
+  add(event: WorkflowEvent) {
     this.queue.push({
       taskId: this.nextTaskId++,
       visibleFrom: Date.now(),

--- a/packages/test-runtime/src/memory-timers.ts
+++ b/packages/test-runtime/src/memory-timers.ts
@@ -1,4 +1,4 @@
-import type { ExecutionEvent } from "@yieldstar/core";
+import type { WorkflowEvent } from "@yieldstar/core";
 import type { MemoryTaskQueue } from "./memory-task-queue";
 
 export class MemoryTimers {
@@ -10,7 +10,7 @@ export class MemoryTimers {
     this.timers = new Set();
   }
 
-  startTimer(event: ExecutionEvent, duration: number) {
+  startTimer(event: WorkflowEvent, duration: number) {
     const timer = setTimeout(() => {
       this.taskQueue.add(event);
       this.timers.delete(timer);

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldstar/test-utils",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/test-utils/src/workflow-runner.ts
+++ b/packages/test-utils/src/workflow-runner.ts
@@ -36,9 +36,9 @@ export function createTestSdkFactory(params?: { logger?: Logger }) {
     return {
       async triggerAndWait<
         K extends keyof W & string,
-        EventParams = EventParamsOf<W[K]>
+        Params extends EventParamsOf<W[K]> = EventParamsOf<W[K]>
       >(
-        event: TriggerEvent<K, EventParams>
+        event: TriggerEvent<K, Params>
       ): Promise<WorkflowGeneratorReturnType<W[K]>> {
         memoryEventLoop.start({ onNewEvent: invoker.execute });
 

--- a/packages/yieldstar/package.json
+++ b/packages/yieldstar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yieldstar",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/yieldstar/src/exports/sdk-http.ts
+++ b/packages/yieldstar/src/exports/sdk-http.ts
@@ -7,7 +7,7 @@ import type {
 } from "@yieldstar/core";
 import { nanoid } from "nanoid";
 import { deserializeError } from "serialize-error";
-import { errorWithOriginalStack } from "../internal/serialise";
+import { errorWithOriginalStack } from "@yieldstar/core";
 
 type TriggerAck = {
   executionId: string;

--- a/packages/yieldstar/src/exports/workflow.ts
+++ b/packages/yieldstar/src/exports/workflow.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import type { ExecutionEvent, WorkflowGenerator } from "@yieldstar/core";
+import type { WorkflowEvent, WorkflowGenerator } from "@yieldstar/core";
 import type { StepRunner } from "../internal/step-runner";
 import { isIterable } from "../internal/utils";
 import {
@@ -18,15 +18,19 @@ import {
   WorkflowResult,
 } from "@yieldstar/core";
 
-export type WorkflowFn<EventParams, Result> = (
+export type WorkflowFn<EventParams, Result, Context extends Map<any, any>> = (
   step: StepRunner,
-  event: ExecutionEvent<EventParams>,
+  event: WorkflowEvent<EventParams, Context>,
   logger: Logger
 ) => AsyncGenerator<any, Result>;
 
-export function workflow<EventParams = void, Result = void>(
-  workflowFn: WorkflowFn<EventParams, Result>
-): WorkflowGenerator<EventParams, Result> {
+export function workflow<
+  EventParams = void,
+  Result = void,
+  Context extends Map<any, any> = Map<any, any>
+>(
+  workflowFn: WorkflowFn<EventParams, Result, Context>
+): WorkflowGenerator<EventParams, Result, Context> {
   /**
    * @description Advances workflow steps, handling any workflow logic, and
    * yielding control to a workflow executor to do async work

--- a/packages/yieldstar/src/exports/workflow.ts
+++ b/packages/yieldstar/src/exports/workflow.ts
@@ -1,5 +1,10 @@
 import type { Logger } from "pino";
-import type { WorkflowEvent, WorkflowGenerator } from "@yieldstar/core";
+import type {
+  WorkflowEvent,
+  WorkflowGenerator,
+  EventParams,
+  EventContext,
+} from "@yieldstar/core";
 import type { StepRunner } from "../internal/step-runner";
 import { isIterable } from "../internal/utils";
 import {
@@ -18,19 +23,23 @@ import {
   WorkflowResult,
 } from "@yieldstar/core";
 
-export type WorkflowFn<EventParams, Result, Context extends Map<any, any>> = (
+export type WorkflowFn<
+  Params extends EventParams,
+  Result,
+  Context extends EventContext
+> = (
   step: StepRunner,
-  event: WorkflowEvent<EventParams, Context>,
+  event: WorkflowEvent<Params, Context>,
   logger: Logger
 ) => AsyncGenerator<any, Result>;
 
 export function workflow<
-  EventParams = void,
-  Result = void,
-  Context extends Map<any, any> = Map<any, any>
+  Params extends EventParams,
+  Result,
+  Context extends EventContext
 >(
-  workflowFn: WorkflowFn<EventParams, Result, Context>
-): WorkflowGenerator<EventParams, Result, Context> {
+  workflowFn: WorkflowFn<Params, Result, Context>
+): WorkflowGenerator<Params, Result, Context> {
   /**
    * @description Advances workflow steps, handling any workflow logic, and
    * yielding control to a workflow executor to do async work

--- a/packages/yieldstar/src/internal/serialise.ts
+++ b/packages/yieldstar/src/internal/serialise.ts
@@ -7,13 +7,6 @@ import {
 } from "@yieldstar/core";
 import { isErrorLike, serializeError, deserializeError } from "serialize-error";
 
-export function errorWithOriginalStack(error: Error, fn: Function) {
-  const err = new Error(error.message);
-  Error.captureStackTrace(err, fn);
-  err.stack = error.stack;
-  throw err;
-}
-
 export function serializeStepResponse(data: StepResponse): string {
   const replaceErrors = (key: string, value: any) => {
     if (value instanceof Error) {

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yieldstar-test",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.1",
   "private": true,
   "dependencies": {
     "@yieldstar/test-utils": "workspace:*",


### PR DESCRIPTION
Adds support for context in workflows and HTTP middleware.

Currently middleware can be attached to the HTTP server.

```typescript
const middleware = createMiddleware(async (req, event, next, logger) => {
  // Before workflow invocation
  event.context.set('key', 'value');
  
  // Continue to next middleware
  const response = await next();
  
  // After workflow invocation
  response.headers.set('X-Custom-Header', 'value');
  return response;
});

const server = createWorkflowHttpServer({
  port: 8080,
  logger,
  invoker,
  middleware: [middleware]
});
```

When a workflow is invoked, the event object now includes `context`.

```ts
import { workflow } from "yieldstar";

export const simpleWorkflow = workflow(async function* (step, event, logger) {
  const key = event.context.get('key');
  yield* step.delay(1000);
  return key;
});
```

Mutations to context during workflow phases are not persisted.  

Todo: 

- [x] disable `context.set` to make prevent context being mutated in workflows
- [x] throw an error from middleware if context is mutated after calling next 