### PR TITLE
Expose event context in worker process

### DIFF
--- a/packages/bun-worker-invoker/src/bun-worker.ts
+++ b/packages/bun-worker-invoker/src/bun-worker.ts
@@ -1,11 +1,16 @@
 import type { Logger } from "pino";
 import type {
+  EventContext,
   MiddlewareEvent,
   WorkflowEvent,
   WorkflowRunner,
 } from "@yieldstar/core";
 import { ReadOnlyMap } from "@yieldstar/core";
 import { serializeError } from "serialize-error";
+
+let context: EventContext;
+
+export const getContext = () => context;
 
 export function createWorkflowWorker(
   workflowRunner: WorkflowRunner<any>,
@@ -18,6 +23,7 @@ export function createWorkflowWorker(
           ...event,
           context: new ReadOnlyMap(event.context),
         };
+        context = workflowEvent.context;
         try {
           const response = await workflowRunner.run(workflowEvent, logger);
           process.send!({ status: "completed", response });

--- a/packages/bun-worker-invoker/src/index.ts
+++ b/packages/bun-worker-invoker/src/index.ts
@@ -1,2 +1,2 @@
 export { createWorkflowInvoker } from "./bun-worker-invoker";
-export { createWorkflowWorker } from "./bun-worker";
+export { createWorkflowWorker, getContext } from "./bun-worker";


### PR DESCRIPTION
Workflows are invoked once per process so we can easily expose the context to any code running in that process.

```ts
import { getContext } from '@yieldstar/bun-worker-invoker';

function makeRequestUtil() {
  const context = getContext();
  const authToken = context.get('token');
  ...
}
```