### PR TITLE
Pass context via SDK

### DIFF
--- a/examples/http-server/app.ts
+++ b/examples/http-server/app.ts
@@ -2,13 +2,19 @@ import { createHttpSdkFactory } from "yieldstar";
 import type { WorkflowRouter } from "./shared";
 
 export const createSdk = createHttpSdkFactory<WorkflowRouter>();
-const sdk = createSdk({ host: "localhost", port: 8080 });
+const sdk = createSdk({ url: "http://localhost:8080" });
 
 try {
   const execution = await sdk.trigger({
-    workflowId: "dynamic-workflow",
+    workflowId: "simple-workflow",
     params: {
       msg: "world!",
+    },
+    context: {
+      user: {
+        id: "123",
+        name: "John Doe",
+      },
     },
   });
 

--- a/examples/http-server/server.ts
+++ b/examples/http-server/server.ts
@@ -1,8 +1,5 @@
 import pino from "pino";
-import {
-  createMiddleware,
-  createWorkflowHttpServer,
-} from "@yieldstar/bun-http-server";
+import { createMiddleware, createRoutes } from "@yieldstar/bun-http-server";
 import { createWorkflowInvoker } from "@yieldstar/bun-worker-invoker";
 import { sqliteEventLoop } from "./shared";
 
@@ -13,6 +10,8 @@ const invoker = createWorkflowInvoker({
   workerPath,
   logger,
 });
+
+sqliteEventLoop.start({ onNewEvent: invoker.execute, logger });
 
 const authMiddleware = createMiddleware(async (req, event, next) => {
   const token = req.headers.get("Authorization");
@@ -31,12 +30,14 @@ const corsMiddleware = createMiddleware(async (req, event, next) => {
   return response;
 });
 
-const server = createWorkflowHttpServer({
+Bun.serve({
   port: 8080,
-  logger,
-  invoker,
-  middleware: [corsMiddleware, authMiddleware],
+  routes: {
+    "/status": new Response("OK"),
+    ...createRoutes({
+      logger,
+      invoker,
+      middleware: [corsMiddleware, authMiddleware],
+    }),
+  },
 });
-
-sqliteEventLoop.start({ onNewEvent: invoker.execute, logger });
-server.serve();

--- a/packages/bun-http-server/README.md
+++ b/packages/bun-http-server/README.md
@@ -37,7 +37,7 @@ logger.info(`Server started on port ${server.url}`);
 Bun.serve({
   port: 3000,
   routes: {
-    "status": new Reponse('OK')
+    "/status": new Response('OK')
       // mount workflow routes on /workflow
     ...createRoutes({
       basePath: "/workflow",

--- a/packages/bun-http-server/src/bun-server.ts
+++ b/packages/bun-http-server/src/bun-server.ts
@@ -22,7 +22,9 @@ export const createTriggerHandler =
 
     const event: MiddlewareEvent = {
       ...executionEvent,
-      context: new FreezableMap<string, any>(),
+      context: new FreezableMap<string, any>(
+        Object.entries(executionEvent.context ?? {})
+      ),
     };
 
     return executeMiddlewareChain(

--- a/packages/core/src/base/event.ts
+++ b/packages/core/src/base/event.ts
@@ -12,17 +12,20 @@ export type TriggerEvent<
       workflowId: WorkflowId;
       executionId?: string;
       params?: undefined;
+      context?: Record<string, any>;
     }
   : {
       workflowId: WorkflowId;
       executionId?: string;
       params: Params;
+      context?: Record<string, any>;
     };
 
 export type ExecutionEvent<Params extends EventParams = EventParams> = {
   workflowId: string;
   executionId: string;
   params: Params;
+  context?: Record<string, any>;
 };
 
 export type WorkflowEvent<

--- a/packages/yieldstar/src/exports/sdk-http.ts
+++ b/packages/yieldstar/src/exports/sdk-http.ts
@@ -32,6 +32,7 @@ export function createHttpSdkFactory<W extends WorkflowRouter>() {
           executionId: event?.executionId ?? nanoid(),
           workflowId: event?.workflowId as string,
           params: event?.params,
+          context: event?.context,
         };
 
         const res = await fetch(`${params.url}/trigger`, {


### PR DESCRIPTION
Enables passing an initial context in SDK calls:

```ts
await sdk.trigger({
    workflowId: "my-workflow",
    params: {
      msg: "hello world!",
    },
    context: {
      user: {
        id: "123",
        name: "John Doe",
      },
    },
  });
  ```