### PR TITLE
Add Dockerfile with postgres support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Project Notes
+
+## Running Postgres locally
+
+The Dockerfile installs PostgreSQL and initializes a default data directory. Build and run the container to start a local database:
+
+```bash
+docker build -t yieldstar-dev .
+docker run --rm -p 5432:5432 yieldstar-dev
+```
+
+Inside the container you can create a database with `createdb mydb` and connect using `psql mydb`. From the host, connect to `localhost:5432` with user `postgres`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM ghcr.io/codex-src/codex-universal:2
 
-USER root
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql postgresql-contrib && \
-    rm -rf /var/lib/apt/lists/*
+apt-get update && apt-get install -y postgresql postgresql-contrib
 
-USER postgres
-ENV PGDATA=/var/lib/postgresql/data
-RUN mkdir -p $PGDATA && initdb -D $PGDATA
+service postgresql start
 
-EXPOSE 5432
-CMD ["postgres", "-D", "/var/lib/postgresql/data", "-c", "listen_addresses=*" ]
+sudo -u postgres createdb yieldstar-test
+sudo -u postgres psql -c "CREATE USER testuser WITH PASSWORD 'testpass';"
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE yieldstar-test TO testuser;"
+sudo -u postgres psql -c "ALTER USER testuser CREATEDB;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/codex-src/codex-universal:2
+
+USER root
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql postgresql-contrib && \
+    rm -rf /var/lib/apt/lists/*
+
+USER postgres
+ENV PGDATA=/var/lib/postgresql/data
+RUN mkdir -p $PGDATA && initdb -D $PGDATA
+
+EXPOSE 5432
+CMD ["postgres", "-D", "/var/lib/postgresql/data", "-c", "listen_addresses=*" ]


### PR DESCRIPTION
## Summary
- add Dockerfile based on codex-universal with Postgres installed
- document starting a Postgres instance in `AGENTS.md`

## Testing
- `bun test` *(fails: Cannot find package 'yieldstar')*

------
https://chatgpt.com/codex/tasks/task_e_6841d21945ac83219c5150c30c211429