### PR TITLE
Use step call site as default cache key

### DIFF
--- a/packages/core/src/base/step.ts
+++ b/packages/core/src/base/step.ts
@@ -5,8 +5,8 @@ export abstract class StepResponse {
 export class StepKey extends StepResponse {
   static type = "step-key";
   readonly type = "step-key";
-  key: string | null;
-  constructor(key: string | null) {
+  key: string;
+  constructor(key: string) {
     super();
     this.key = key;
   }

--- a/packages/core/src/lib/workflow-runner.ts
+++ b/packages/core/src/lib/workflow-runner.ts
@@ -73,6 +73,7 @@ export class WorkflowRunner<
       logger,
     });
 
+
     const iteratorResult = await workflowIterator.next();
     const stageResponse = iteratorResult.value;
 

--- a/packages/yieldstar/src/exports/workflow.ts
+++ b/packages/yieldstar/src/exports/workflow.ts
@@ -49,9 +49,9 @@ export function workflow<
     const workflowIterator = workflowFn(stepRunner, event, logger);
     const { executionId } = event;
 
-    let keylessStepIndex = -1;
     let iteratorResult: IteratorResult<any> | null = null;
     let nextIteratorResult: IteratorResult<any> | null = null;
+    const stepKeys = new Set<string>();
 
     while (true) {
       let stepAttempt = 0;
@@ -71,20 +71,20 @@ export function workflow<
 
       /**
        * Get the StepKey from the step runner.
-       * If the StepKey value is null, assume deterministic ordering, and use
-       * the step index as a key.
        * If the generator is done, the workflow has returned, so we set a
        * special key for that.
+       * Finally, check that this call site wasn't reached before.
        */
       if (iteratorResult.done) {
         stepKey = "$$workflow-result$$";
       } else if (!(iteratorResult.value instanceof StepKey)) {
         throw new Error("Step runners must yield a StepKey object");
-      } else if (iteratorResult.value.key) {
-        stepKey = iteratorResult.value.key;
       } else {
-        keylessStepIndex++;
-        stepKey = `$$step-index-${keylessStepIndex}$$`;
+        stepKey = iteratorResult.value.key;
+        if (stepKeys.has(stepKey)) {
+          throw new Error("Each step in a loop must have a unique cache key.");
+        }
+        stepKeys.add(stepKey)
       }
 
       /**

--- a/packages/yieldstar/src/internal/step-runner.ts
+++ b/packages/yieldstar/src/internal/step-runner.ts
@@ -7,6 +7,7 @@ import {
   StepCacheCheck,
 } from "@yieldstar/core";
 import { RetryableError } from "../exports/errors";
+import { getCallSiteHash } from "./utils";
 
 /**
  * @description A library of step generators, each of which:
@@ -21,27 +22,29 @@ export const stepRunner = { run, delay, poll };
 export type StepRunner = typeof stepRunner;
 
 function run<T extends any>(
-  fn: () => T | Promise<T>
+  fn: () => T | Promise<T>,
 ): AsyncGenerator<StepResponse, T, StepResult | StepError>;
 
 function run<T extends any>(
   key: string,
-  fn: () => T | Promise<T>
+  fn: () => T | Promise<T>,
 ): AsyncGenerator<StepResponse, T, StepResult | StepError>;
 
 async function* run<T extends any>(
   arg1: string | (() => T | Promise<T>),
-  arg2?: () => T | Promise<T>
+  arg2?: (() => T | Promise<T>) | string,
 ): AsyncGenerator<StepResponse, T, StepResult | StepError> {
   let key: string | null = null;
   let fn: () => T | Promise<T>;
 
   if (typeof arg1 === "string") {
     key = arg1;
-    fn = arg2!;
+    fn = arg2 as () => T | Promise<T>;
   } else {
     fn = arg1;
   }
+
+  if (!key) key = getCallSiteHash(run);
 
   yield new StepKey(key);
 
@@ -91,6 +94,8 @@ async function* delay(
     retryInterval = arg1;
   }
 
+  if (!key) key = getCallSiteHash(delay);
+
   yield new StepKey(key);
 
   const cached = yield new StepCacheCheck();
@@ -126,6 +131,8 @@ async function* poll(
     predicate = arg2 as PollPredicate;
   }
 
+  if (!key) key  = getCallSiteHash(poll);
+
   const task = async () => {
     if (!(await predicate())) {
       throw new RetryableError("Polling reached max retries", {
@@ -135,9 +142,5 @@ async function* poll(
     }
   };
 
-  if (key) {
-    yield* run(key, task);
-  } else {
-    yield* run(task);
-  }
+  yield* run(key, task, );
 }

--- a/packages/yieldstar/src/internal/utils.ts
+++ b/packages/yieldstar/src/internal/utils.ts
@@ -1,5 +1,25 @@
+import { createHash } from "crypto";
+
 export const isIterable = <T>(i: T | Iterable<T>): i is Iterable<T> => {
   return (
     typeof i === "object" && i != null && Symbol.iterator in (i as Iterable<T>)
   );
 };
+
+
+export function getCallSiteHash(stepFn: Function) {
+  const originalStack = (stepFn as any).stack;
+
+  Error.captureStackTrace(stepFn, getCallSiteHash);
+
+  const stack = (stepFn as any).stack
+  const stepFnCallSite = stack.split(')')[1]
+
+  if (originalStack === undefined) {
+    delete (stepFn as any).stack;
+  } else {
+    (stepFn as any).stack = originalStack;
+  }
+
+  return createHash("sha1").update(stepFnCallSite).digest("hex");
+}

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -2,23 +2,24 @@ import type { WorkflowFn } from "yieldstar";
 import { expect, test, mock } from "bun:test";
 import { createWorkflow } from "yieldstar";
 import { createTestSdkFactory } from "@yieldstar/test-utils";
+import { EventContext } from "../packages/core/dist";
 
 const createSdk = createTestSdkFactory();
 
 test("running sync workflows to completion", async () => {
-  const mockWorkflowGenerator = mock<WorkflowFn<undefined, number>>(
-    async function* (step, event, logger) {
-      let num = yield* step.run(() => {
-        return 1;
-      });
+  const mockWorkflowGenerator = mock<
+    WorkflowFn<undefined, number, EventContext>
+  >(async function* (step) {
+    let num = yield* step.run(() => {
+      return 1;
+    });
 
-      num = yield* step.run(() => {
-        return Promise.resolve(num * 2);
-      });
+    num = yield* step.run(() => {
+      return Promise.resolve(num * 2);
+    });
 
-      return num;
-    }
-  );
+    return num;
+  });
 
   const workflow = createWorkflow(mockWorkflowGenerator);
   const sdk = createSdk({ workflow });

--- a/test/cache-keys.test.ts
+++ b/test/cache-keys.test.ts
@@ -24,7 +24,7 @@ test("step.run without cache keys", async () => {
   await sdk.triggerAndWait({ workflowId: "workflow" });
 
   expect(mock1).toBeCalledTimes(1);
-  expect(mock2).not.toBeCalled();
+  expect(mock2).toBeCalledTimes(1);
 });
 
 test("step.run with cache keys", async () => {
@@ -69,9 +69,9 @@ test("step.delay without cache keys", async () => {
 
   let duration = Date.now() - startTime;
 
-  // expect second delay to be a cache hit
-  expect(duration).toBeGreaterThanOrEqual(10);
-  expect(duration).toBeLessThan(15);
+  // expect both delays to be invoked
+  expect(duration).toBeGreaterThanOrEqual(20);
+  expect(duration).toBeLessThan(25);
 });
 
 test("step.delay with cache keys", async () => {
@@ -96,35 +96,4 @@ test("step.delay with cache keys", async () => {
   // expect second delay to trigger a new timer
   expect(duration).toBeGreaterThanOrEqual(20);
   expect(duration).toBeLessThan(25);
-});
-
-test("interlacing cache keys and cache indexes", async () => {
-  let executionIdx = -1;
-
-  const workflow = createWorkflow(async function* (step) {
-    executionIdx++;
-    let volatileNum = 0;
-    let stableNum = 0;
-
-    // a different step will run on re-invocation of the workflow
-    // therefore the steps need cache keys
-    if (executionIdx === 0) {
-      stableNum = yield* step.run("step-1", () => 1);
-      volatileNum = yield* step.run(() => 1);
-    } else {
-      volatileNum = yield* step.run(() => 2);
-      stableNum = yield* step.run("step-2", () => 2);
-    }
-
-    // trigger a second invocation of the workflow
-    yield* step.delay(100);
-
-    return { stableNum, volatileNum };
-  });
-
-  const sdk = createSdk({ workflow });
-  const result = await sdk.triggerAndWait({ workflowId: "workflow" });
-
-  expect(result.stableNum).toBe(2);
-  expect(result.volatileNum).toBe(1);
 });

--- a/test/loop-detection.test.ts
+++ b/test/loop-detection.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, mock } from "bun:test";
+import { createWorkflow } from "yieldstar";
+import { createTestSdkFactory } from "@yieldstar/test-utils";
+
+const createSdk = createTestSdkFactory();
+
+test("loop detection with implicit keys", async () => {
+  const runSpy = mock(() => 1);
+
+  const workflow = createWorkflow(async function* (step) {
+    for (let i = 0; i < 2; i++) {
+      yield* step.run(runSpy);
+    }
+  });
+
+  const sdk = createSdk({ workflow });
+  const result = await sdk.triggerAndWait({ workflowId: "workflow" });
+
+  // The loop should be detected on the second attempt, so the function
+  // backing step.run should only be executed once
+  expect(runSpy).toBeCalledTimes(1);
+
+  expect(result).toBeInstanceOf(Error);
+  expect((result as unknown as Error).message).toContain(
+    "Each step in a loop must have a unique cache key.",
+  );
+});
+
+test("no loop detection with explicit keys", async () => {
+  const runSpy = mock(() => 1);
+
+  const workflow = createWorkflow(async function* (step) {
+    for (let i = 0; i < 2; i++) {
+      yield* step.run(`cache-key-${i}`, runSpy);
+    }
+  });
+
+  const sdk = createSdk({ workflow });
+  const result = await sdk.triggerAndWait({ workflowId: "workflow" });
+
+  expect(runSpy).toBeCalledTimes(2);
+  expect(result).toBe(undefined);
+});


### PR DESCRIPTION
See original discussion in #8 

Currently cache keys are either passed in explicitly or they default to an ordered number. 

This can result in the wrong cached item being retrieved for steps that are occur in loops or non-deterministic order. We currently do not have a mechanism (runtime or linter) to warn the user about this.

This PR replaces step indexes with a hash of the step function's call site (file name and line number) to provide a stable cache key.

When the same cache key occurs in a single workflow run (e.g. step is in a loop or ordering is not deterministic) an error is thrown and the user is instructed to add explicit cache keys.

Caveats
- Call sites may change between deployments. This will need to be taken into account when considering whether cached items are scoped to a particular deployment.
- Loop detection only operates within a single workflow pass. If the workflow pauses and resumes the record of cache keys is reset. This is probably the desired behaviour but some consideration should be given to whether they are persisted. 
