### PR TITLE
Add durable store lifecycle management

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -163,6 +163,7 @@ type StorePath = readonly (string | number | symbol)[]
 
 type StoreSnapshot<T> = {
   state: T
+  storePk: string // UUIDv7 identifying this physical incarnation
   version: StoreVersion
 }
 
@@ -190,6 +191,17 @@ interface WorkflowStore<T> {
     key: string,
     updater: (draft: Draft<T>) => void | T | Promise<void | T>
   ): AsyncGenerator<StepResponse, StoreUpdateResult<T>>
+
+  updateFrom(
+    key: string,
+    snapshot: StoreSnapshot<T>,
+    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+  ): AsyncGenerator<StepResponse, StoreUpdateFromResult<T>>
+
+  deleteFrom(
+    key: string,
+    snapshot: StoreSnapshot<T>
+  ): AsyncGenerator<StepResponse, StoreDeleteFromResult>
 
   when<R>(
     selector: StoreSelector<T, R | undefined | null | false>
@@ -424,6 +436,13 @@ interface RuntimeStore<T> {
   update(
     updater: (draft: Draft<T>) => void | T | Promise<void | T>
   ): Promise<StoreUpdateResult<T>>
+
+  updateFrom(
+    snapshot: StoreSnapshot<T>,
+    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+  ): Promise<StoreUpdateFromResult<T>>
+
+  deleteFrom(snapshot: StoreSnapshot<T>): Promise<StoreDeleteFromResult>
 }
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -163,7 +163,7 @@ type StorePath = readonly (string | number | symbol)[]
 
 type StoreSnapshot<T> = {
   state: T
-  storePk: string // UUIDv7 identifying this physical incarnation
+  instanceId: string // UUIDv7 assigned when this store instance is created
   version: StoreVersion
 }
 

--- a/docs/manual/store-external.md
+++ b/docs/manual/store-external.md
@@ -20,12 +20,13 @@ The constructor takes a scheduler as well as the database. When a write changes 
 ## Reading
 
 ```ts
-const { state, storePk, version } = await conversation.get();
+const { state, instanceId, version } = await conversation.get();
 ```
 
-`storePk` is an internal UUIDv7 identifying this physical incarnation. A store
-deleted and recreated under the same logical definition and ID receives a new
-primary key and starts again at version zero.
+`instanceId` is an internal UUIDv7 assigned when the store is created. It stays
+the same for the lifetime of that store. Deleting and recreating the same
+logical definition and ID assigns a new instance ID and resets the version to
+zero.
 
 ## Writing
 
@@ -57,7 +58,7 @@ const current = await conversation.get();
 const deleted = await conversation.deleteFrom(current);
 ```
 
-They commit only if both `storePk` and `version` still match. `StoreClient`
+They commit only if both `instanceId` and `version` still match. `StoreClient`
 also exposes `listStores(definition)`, which returns sorted live logical IDs,
 and idempotent unconditional `deleteStore({ definition, id })` for
 administrative cleanup.

--- a/docs/manual/store-external.md
+++ b/docs/manual/store-external.md
@@ -20,8 +20,12 @@ The constructor takes a scheduler as well as the database. When a write changes 
 ## Reading
 
 ```ts
-const { state, version } = await conversation.get();
+const { state, storePk, version } = await conversation.get();
 ```
+
+`storePk` is an internal UUIDv7 identifying this physical incarnation. A store
+deleted and recreated under the same logical definition and ID receives a new
+primary key and starts again at version zero.
 
 ## Writing
 
@@ -38,6 +42,25 @@ await conversation.update((draft) => {
 ```
 
 If a workflow is suspended on `store.when` or `store.take` over `s.messages`, this write wakes it. That is the whole event-ingestion story: the webhook handler writes state, and the workflow that cares about that state resumes.
+
+When a write or deletion depends on an earlier snapshot, use the conditional
+operations:
+
+```ts
+const snapshot = await conversation.get();
+
+const updated = await conversation.updateFrom(snapshot, (draft) => {
+  draft.status = "synced";
+});
+
+const current = await conversation.get();
+const deleted = await conversation.deleteFrom(current);
+```
+
+They commit only if both `storePk` and `version` still match. `StoreClient`
+also exposes `listStores(definition)`, which returns sorted live logical IDs,
+and idempotent unconditional `deleteStore({ definition, id })` for
+administrative cleanup.
 
 ## The pattern in full
 

--- a/docs/manual/stores.md
+++ b/docs/manual/stores.md
@@ -86,6 +86,34 @@ What if the process crashes after the store commits, but before the step result 
 
 Keep updaters synchronous and pure. The signature allows async, but an updater holds the store's write transaction open while it runs – no network calls, no timers.
 
+When a decision depends on an earlier read, use `updateFrom` to commit only if
+the store has not changed since that snapshot:
+
+```ts
+const snapshot = yield* store.get("load-before-sync");
+const remote = yield* step.run("sync-remote", () =>
+  syncRemote(snapshot.state)
+);
+
+const result = yield* store.updateFrom(
+  "save-remote-result",
+  snapshot,
+  (draft) => {
+    draft.remoteId = remote.id;
+  }
+);
+
+if (!result.updated) {
+  // The updater did not run. Read fresh state and reconcile in new steps.
+}
+```
+
+The successful branch contains the same state and version fields as
+`store.update`, plus `updated: true`. A conflict returns `updated: false`, the
+snapshot's `expectedVersion`, and the store's `actualVersion`. Both outcomes
+are durable step results. A retry after a conflict must use a fresh read and a
+new step key.
+
 ## Waiting
 
 To pause a workflow until the store reaches some condition, see [Waiting on State](./store-waiting.md).

--- a/docs/manual/stores.md
+++ b/docs/manual/stores.md
@@ -48,12 +48,13 @@ Pass an explicit `id` to share one store across executions – a conversation id
 
 ## Reading
 
-`store.get` returns a snapshot containing the state, a version number that
-increments on each update, and an internal UUIDv7 `storePk` identifying this
-physical incarnation of the logical `(definition, id)` store.
+`store.get` returns a snapshot containing the state and a version number that
+increments on each update. The snapshot also contains an internal UUIDv7
+`instanceId`, assigned when the store is created. Deleting and recreating the
+same logical store assigns a new instance ID.
 
 ```ts
-const { state, storePk, version } = yield* store.get("load");
+const { state, instanceId, version } = yield* store.get("load");
 ```
 
 `store.select` runs a pure selector and persists only the selected value:
@@ -112,7 +113,7 @@ if (!result.updated) {
 
 The successful branch contains the same state and version fields as
 `store.update`, plus `updated: true`. A conflict returns `updated: false` and
-the expected and actual primary keys and versions. Comparing both values
+the expected and actual instance IDs and versions. Comparing both values
 prevents an old snapshot from matching a deleted and recreated store whose
 version happens to be the same. Both outcomes are durable step results. A
 retry after a conflict must use a fresh read and a new step key.
@@ -130,11 +131,11 @@ if (!result.deleted) {
 }
 ```
 
-The store is deleted only when both its UUIDv7 primary key and version still
-match the snapshot. Successful workflow deletions are written to the
-applied-steps ledger before commit, and that ledger entry survives deletion.
-Replay therefore returns the committed result without deleting a newer store
-created under the same logical ID.
+The store is deleted only when its instance ID and version still match the
+snapshot. Successful workflow deletions are written to the applied-steps
+ledger before commit, and that ledger entry survives deletion. Replay therefore
+returns the committed result without deleting a newer store created under the
+same logical ID.
 
 Runtime integrations can call `listStores(definition)` to get the definition's
 live logical IDs in ascending order, and `deleteStore({ definition, id })` for

--- a/docs/manual/stores.md
+++ b/docs/manual/stores.md
@@ -48,10 +48,12 @@ Pass an explicit `id` to share one store across executions – a conversation id
 
 ## Reading
 
-`store.get` returns a snapshot: the state plus a version number that increments on each update.
+`store.get` returns a snapshot containing the state, a version number that
+increments on each update, and an internal UUIDv7 `storePk` identifying this
+physical incarnation of the logical `(definition, id)` store.
 
 ```ts
-const { state, version } = yield* store.get("load");
+const { state, storePk, version } = yield* store.get("load");
 ```
 
 `store.select` runs a pure selector and persists only the selected value:
@@ -109,10 +111,35 @@ if (!result.updated) {
 ```
 
 The successful branch contains the same state and version fields as
-`store.update`, plus `updated: true`. A conflict returns `updated: false`, the
-snapshot's `expectedVersion`, and the store's `actualVersion`. Both outcomes
-are durable step results. A retry after a conflict must use a fresh read and a
-new step key.
+`store.update`, plus `updated: true`. A conflict returns `updated: false` and
+the expected and actual primary keys and versions. Comparing both values
+prevents an old snapshot from matching a deleted and recreated store whose
+version happens to be the same. Both outcomes are durable step results. A
+retry after a conflict must use a fresh read and a new step key.
+
+## Deleting
+
+Use `deleteFrom` when deletion is based on a snapshot:
+
+```ts
+const snapshot = yield* store.get("load-before-delete");
+const result = yield* store.deleteFrom("delete", snapshot);
+
+if (!result.deleted) {
+  // The store changed, was recreated, or was already removed.
+}
+```
+
+The store is deleted only when both its UUIDv7 primary key and version still
+match the snapshot. Successful workflow deletions are written to the
+applied-steps ledger before commit, and that ledger entry survives deletion.
+Replay therefore returns the committed result without deleting a newer store
+created under the same logical ID.
+
+Runtime integrations can call `listStores(definition)` to get the definition's
+live logical IDs in ascending order, and `deleteStore({ definition, id })` for
+an unconditional, idempotent administrative deletion. Prefer `deleteFrom`
+when the deletion decision was made from previously read state.
 
 ## Waiting
 

--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -91,6 +91,18 @@ abstract updateStore(params: {
   stepId?: StoreStepId; // identifies the workflow step; keys the applied-steps ledger
 }): Promise<StoreUpdateResult>;
 
+abstract updateStoreFrom(params: {
+  definition: StoreDefinition;
+  id: string;
+  snapshot: StoreSnapshot;
+  updater: (draft: Draft) => void | State;
+  stepId?: StoreStepId;
+}): Promise<StoreUpdateFromResult>;
+
+abstract listStores(definition: StoreDefinition): Promise<string[]>;
+abstract deleteStore(params: { definition: StoreDefinition; id: string }): Promise<void>;
+abstract deleteStoreFrom(params): Promise<StoreDeleteFromResult>;
+
 abstract takeFromStore(params): Promise<StoreTakeResult>;
 
 abstract registerWaiter(waiter: StoreWaiter): Promise<void>;
@@ -100,9 +112,11 @@ The base class also provides `storeClient.store(definition, id)`, the external r
 
 An implementation must uphold four contracts:
 
+- Every physical store incarnation has a UUIDv7 primary key; `(definition.name, id)` remains the unique logical lookup key.
 - Each update commits in a single per-store transaction and increments the version by one.
+- Snapshot-based updates and deletions compare both the incarnation primary key and version.
 - When `stepId` is provided and the ledger already holds that step, the implementation returns the recorded result and does not run the updater.
-- `registerWaiter` compares the store's current version with the waiter's `sinceVersion`; if the store has moved on, it wakes the waiter immediately rather than leaving it to sleep through a write that already happened.
+- `registerWaiter` compares the store's current incarnation and version with the waiter; if either has moved on, it wakes the waiter immediately rather than leaving it to sleep through a write that already happened.
 - A waiter is removed only after its wake-up is queued. A crash in between produces a duplicate wake, which replay absorbs – the reverse order would lose the wake entirely.
 
 ## `WorkflowInvoker` (type)

--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -112,11 +112,11 @@ The base class also provides `storeClient.store(definition, id)`, the external r
 
 An implementation must uphold four contracts:
 
-- Every physical store incarnation has a UUIDv7 primary key; `(definition.name, id)` remains the unique logical lookup key.
+- Every store instance has a UUIDv7 instance ID; `(definition.name, id)` remains the unique logical lookup key.
 - Each update commits in a single per-store transaction and increments the version by one.
-- Snapshot-based updates and deletions compare both the incarnation primary key and version.
+- Snapshot-based updates and deletions compare both the instance ID and version.
 - When `stepId` is provided and the ledger already holds that step, the implementation returns the recorded result and does not run the updater.
-- `registerWaiter` compares the store's current incarnation and version with the waiter; if either has moved on, it wakes the waiter immediately rather than leaving it to sleep through a write that already happened.
+- `registerWaiter` compares the store's current instance and version with the waiter; if either has moved on, it wakes the waiter immediately rather than leaving it to sleep through a write that already happened.
 - A waiter is removed only after its wake-up is queued. A crash in between produces a duplicate wake, which replay absorbs – the reverse order would lose the wake entirely.
 
 ## `WorkflowInvoker` (type)

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,6 +8,7 @@
     "@yieldstar/bun-worker-invoker": "workspace:*",
     "@yieldstar/core": "workspace:*",
     "pino": "^9.9.0",
+    "valibot": "^1.4.2",
     "yieldstar": "workspace:*"
   },
   "devDependencies": {

--- a/examples/workflows/store.ts
+++ b/examples/workflows/store.ts
@@ -1,17 +1,18 @@
-import type { StandardSchemaV1 } from "yieldstar";
+import * as v from "valibot";
 import { defineStore, workflow } from "yieldstar";
 
-type ConversationState = {
-  messages: Array<{
-    id: string;
-    content: string;
-  }>;
-};
+const ConversationSchema = v.object({
+  messages: v.array(
+    v.object({
+      id: v.string(),
+      content: v.string(),
+    })
+  ),
+});
 
-const ConversationStore = defineStore(
-  "conversation",
-  schema<ConversationState>()
-);
+type ConversationState = v.InferOutput<typeof ConversationSchema>;
+
+const ConversationStore = defineStore("conversation", ConversationSchema);
 
 export const storeWorkflow = workflow<
   { conversationId: string; content: string },
@@ -32,15 +33,3 @@ export const storeWorkflow = workflow<
   const snapshot = yield* conversation.get("read-conversation");
   return snapshot.state;
 });
-
-function schema<T>(): StandardSchemaV1<unknown, T> {
-  return {
-    "~standard": {
-      version: 1,
-      vendor: "example",
-      validate(value) {
-        return { value: value as T };
-      },
-    },
-  };
-}

--- a/examples/workflows/store.ts
+++ b/examples/workflows/store.ts
@@ -1,5 +1,10 @@
 import * as v from "valibot";
-import { defineStore, workflow } from "yieldstar";
+import { defineStore, workflow, type WorkflowEvent } from "yieldstar";
+
+type ConversationParams = {
+  conversationId: string;
+  content: string;
+};
 
 const ConversationSchema = v.object({
   messages: v.array(
@@ -10,14 +15,12 @@ const ConversationSchema = v.object({
   ),
 });
 
-type ConversationState = v.InferOutput<typeof ConversationSchema>;
-
 const ConversationStore = defineStore("conversation", ConversationSchema);
 
-export const storeWorkflow = workflow<
-  { conversationId: string; content: string },
-  ConversationState
->(async function* (step, event) {
+export const storeWorkflow = workflow(async function* (
+  step,
+  event: WorkflowEvent<ConversationParams>
+) {
   const conversation = yield* step.store(ConversationStore, {
     id: event.params.conversationId,
     initial: { messages: [] },

--- a/examples/workflows/store.ts
+++ b/examples/workflows/store.ts
@@ -1,0 +1,46 @@
+import type { StandardSchemaV1 } from "yieldstar";
+import { defineStore, workflow } from "yieldstar";
+
+type ConversationState = {
+  messages: Array<{
+    id: string;
+    content: string;
+  }>;
+};
+
+const ConversationStore = defineStore(
+  "conversation",
+  schema<ConversationState>()
+);
+
+export const storeWorkflow = workflow<
+  { conversationId: string; content: string },
+  ConversationState
+>(async function* (step, event) {
+  const conversation = yield* step.store(ConversationStore, {
+    id: event.params.conversationId,
+    initial: { messages: [] },
+  });
+
+  yield* conversation.update("append-message", (draft) => {
+    draft.messages.push({
+      id: crypto.randomUUID(),
+      content: event.params.content,
+    });
+  });
+
+  const snapshot = yield* conversation.get("read-conversation");
+  return snapshot.state;
+});
+
+function schema<T>(): StandardSchemaV1<unknown, T> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "example",
+      validate(value) {
+        return { value: value as T };
+      },
+    },
+  };
+}

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -14,6 +14,38 @@ type State = {
 
 const Store = defineStore("sqlite-test", schema<State>());
 
+test("existing stores migrate to UUIDv7 primary keys", async () => {
+  const db = new Database(":memory:");
+  db.run(`
+    CREATE TABLE stores (
+      store_name TEXT NOT NULL,
+      store_id TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      state TEXT NOT NULL,
+      PRIMARY KEY (store_name, store_id)
+    );
+    INSERT INTO stores (store_name, store_id, version, state)
+    VALUES ('sqlite-test', 'legacy', 3, '{"messages":[]}');
+  `);
+
+  const client = new SqliteStoreClient({
+    db,
+    schedulerClient: { async requestWakeUp() {} },
+  });
+  const snapshot = await client.getStore({
+    definition: Store,
+    id: "legacy",
+  });
+
+  expect(snapshot).toMatchObject({ state: { messages: [] }, version: 3 });
+  expect(snapshot.storePk).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7/);
+  const pkColumn = db
+    .query(`PRAGMA table_info(stores)`)
+    .all()
+    .find((column: any) => column.name === "store_pk") as any;
+  expect(pkColumn.pk).toBe(1);
+});
+
 test("sqlite store updates wake matching waiters", async () => {
   const db = new Database(":memory:");
   const events: WorkflowEvent[] = [];
@@ -30,7 +62,7 @@ test("sqlite store updates wake matching waiters", async () => {
     context: new Map(),
   };
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "one",
     initial: { messages: [] },
@@ -42,6 +74,7 @@ test("sqlite store updates wake matching waiters", async () => {
     event,
     storeName: Store.name,
     storeId: "one",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -72,7 +105,7 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
     context: new Map(),
   };
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "stale",
     initial: { messages: [] },
@@ -94,6 +127,7 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
     event,
     storeName: Store.name,
     storeId: "stale",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -193,7 +227,7 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   const replayed = await client.updateStoreFrom({
     definition: Store,
     id: "conditional",
-    snapshot,
+    snapshot: { ...snapshot, storePk: "" },
     stepId,
     updater() {
       updaterRuns++;
@@ -211,10 +245,142 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   });
   expect(conflicted).toEqual({
     updated: false,
+    expectedStorePk: snapshot.storePk,
+    actualStorePk: snapshot.storePk,
     expectedVersion: 0,
     actualVersion: 2,
   });
   expect(updaterRuns).toBe(1);
+});
+
+test("listStores and deleteStore manage logical store instances", async () => {
+  const db = new Database(":memory:");
+  const client = new SqliteStoreClient({
+    db,
+    schedulerClient: { async requestWakeUp() {} },
+  });
+  const OtherStore = defineStore("sqlite-test-other", schema<State>());
+  const first = await client.getOrCreateStore({
+    definition: Store,
+    id: "b",
+    initial: { messages: [] },
+  });
+  const second = await client.getOrCreateStore({
+    definition: Store,
+    id: "a",
+    initial: { messages: [] },
+  });
+  await client.getOrCreateStore({
+    definition: OtherStore,
+    id: "a",
+    initial: { messages: [] },
+  });
+
+  expect(first.storePk).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  expect(second.storePk > first.storePk).toBe(true);
+  expect(await client.listStores(Store)).toEqual(["a", "b"]);
+
+  await client.deleteStore({ definition: Store, id: "b" });
+  expect(await client.listStores(Store)).toEqual(["a"]);
+  expect(client.getStore({ definition: Store, id: "b" })).rejects.toThrow(
+    'Store "sqlite-test:b" does not exist'
+  );
+  await client.deleteStore({ definition: Store, id: "missing" });
+});
+
+test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async () => {
+  const db = new Database(":memory:");
+  const client = new SqliteStoreClient({
+    db,
+    schedulerClient: { async requestWakeUp() {} },
+  });
+  const original = await client.getOrCreateStore({
+    definition: Store,
+    id: "delete-from",
+    initial: { messages: [] },
+  });
+  await client.updateStore({
+    definition: Store,
+    id: "delete-from",
+    updater(draft) {
+      draft.messages.push({ id: "changed" });
+    },
+  });
+
+  const versionConflict = await client.deleteStoreFrom({
+    definition: Store,
+    id: "delete-from",
+    snapshot: original,
+  });
+  expect(versionConflict).toMatchObject({
+    deleted: false,
+    reason: "conflict",
+    expectedStorePk: original.storePk,
+    actualStorePk: original.storePk,
+    expectedVersion: 0,
+    actualVersion: 1,
+  });
+
+  const current = await client.getStore({
+    definition: Store,
+    id: "delete-from",
+  });
+  const stepId = { executionId: "execution", stepKey: "delete" };
+  expect(
+    await client.deleteStoreFrom({
+      definition: Store,
+      id: "delete-from",
+      snapshot: current,
+      stepId,
+    })
+  ).toEqual({ deleted: true });
+
+  expect(
+    await client.deleteStoreFrom({
+      definition: Store,
+      id: "delete-from",
+      snapshot: current,
+    })
+  ).toEqual({
+    deleted: false,
+    reason: "not-found",
+    expectedStorePk: current.storePk,
+    expectedVersion: current.version,
+  });
+
+  const recreated = await client.getOrCreateStore({
+    definition: Store,
+    id: "delete-from",
+    initial: { messages: [] },
+  });
+  expect(recreated.storePk).not.toBe(original.storePk);
+  expect(recreated.version).toBe(0);
+
+  expect(
+    await client.deleteStoreFrom({
+      definition: Store,
+      id: "delete-from",
+      snapshot: current,
+      stepId,
+    })
+  ).toEqual({ deleted: true });
+  expect(
+    await client.getStore({ definition: Store, id: "delete-from" })
+  ).toEqual(recreated);
+
+  const staleUpdate = await client.updateStoreFrom({
+    definition: Store,
+    id: "delete-from",
+    snapshot: original,
+    updater() {},
+  });
+  expect(staleUpdate).toMatchObject({
+    updated: false,
+    expectedStorePk: original.storePk,
+    actualStorePk: recreated.storePk,
+    expectedVersion: 0,
+    actualVersion: 0,
+  });
 });
 
 type TakeState = {
@@ -244,7 +410,7 @@ const takeEvent = {
 test("concurrent takers claim distinct items", async () => {
   const { client } = createTakeClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-race",
     initial: { messages: [{ id: "msg-1" }, { id: "msg-2" }] },
@@ -313,7 +479,7 @@ test("take returns readPaths and version when the selector misses", async () => 
 test("a successful take wakes matching waiters", async () => {
   const { client, events } = createTakeClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-wake",
     initial: { messages: [{ id: "msg-1" }] },
@@ -325,6 +491,7 @@ test("a successful take wakes matching waiters", async () => {
     event: takeEvent,
     storeName: TakeStore.name,
     storeId: "take-wake",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -344,7 +511,7 @@ test("a successful take wakes matching waiters", async () => {
 test("take rejects async claims without committing", async () => {
   const { client } = createTakeClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-async",
     initial: { messages: [{ id: "msg-1" }] },
@@ -587,7 +754,7 @@ test("an updater that returns a replacement state wakes waiters via the diff fal
     context: new Map(),
   };
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "replace",
     initial: { messages: [] },
@@ -599,6 +766,7 @@ test("an updater that returns a replacement state wakes waiters via the diff fal
     event,
     storeName: Store.name,
     storeId: "replace",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -623,7 +791,7 @@ test("committed state is proxy-free and structuredClone-able", async () => {
   };
   const client = new SqliteStoreClient({ db, schedulerClient });
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "laundered",
     initial: { messages: [{ id: "msg-1" }] },
@@ -674,7 +842,7 @@ test("a take claim's mutations are recorded and wake matching waiters", async ()
   type TakeState = { messages: { id: string; claimedBy?: string }[] };
   const TakeStore = defineStore("sqlite-take-paths", schema<TakeState>());
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-wake",
     initial: { messages: [{ id: "msg-1" }] },
@@ -686,6 +854,7 @@ test("a take claim's mutations are recorded and wake matching waiters", async ()
     event,
     storeName: TakeStore.name,
     storeId: "take-wake",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages", 0, "claimedBy"]],
   });

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -14,38 +14,6 @@ type State = {
 
 const Store = defineStore("sqlite-test", schema<State>());
 
-test("existing stores migrate to UUIDv7 primary keys", async () => {
-  const db = new Database(":memory:");
-  db.run(`
-    CREATE TABLE stores (
-      store_name TEXT NOT NULL,
-      store_id TEXT NOT NULL,
-      version INTEGER NOT NULL,
-      state TEXT NOT NULL,
-      PRIMARY KEY (store_name, store_id)
-    );
-    INSERT INTO stores (store_name, store_id, version, state)
-    VALUES ('sqlite-test', 'legacy', 3, '{"messages":[]}');
-  `);
-
-  const client = new SqliteStoreClient({
-    db,
-    schedulerClient: { async requestWakeUp() {} },
-  });
-  const snapshot = await client.getStore({
-    definition: Store,
-    id: "legacy",
-  });
-
-  expect(snapshot).toMatchObject({ state: { messages: [] }, version: 3 });
-  expect(snapshot.storePk).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7/);
-  const pkColumn = db
-    .query(`PRAGMA table_info(stores)`)
-    .all()
-    .find((column: any) => column.name === "store_pk") as any;
-  expect(pkColumn.pk).toBe(1);
-});
-
 test("sqlite store updates wake matching waiters", async () => {
   const db = new Database(":memory:");
   const events: WorkflowEvent[] = [];
@@ -74,7 +42,7 @@ test("sqlite store updates wake matching waiters", async () => {
     event,
     storeName: Store.name,
     storeId: "one",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -127,7 +95,7 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
     event,
     storeName: Store.name,
     storeId: "stale",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -227,7 +195,7 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   const replayed = await client.updateStoreFrom({
     definition: Store,
     id: "conditional",
-    snapshot: { ...snapshot, storePk: "" },
+    snapshot: { ...snapshot, instanceId: "" },
     stepId,
     updater() {
       updaterRuns++;
@@ -245,8 +213,8 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   });
   expect(conflicted).toEqual({
     updated: false,
-    expectedStorePk: snapshot.storePk,
-    actualStorePk: snapshot.storePk,
+    expectedInstanceId: snapshot.instanceId,
+    actualInstanceId: snapshot.instanceId,
     expectedVersion: 0,
     actualVersion: 2,
   });
@@ -276,8 +244,10 @@ test("listStores and deleteStore manage logical store instances", async () => {
     initial: { messages: [] },
   });
 
-  expect(first.storePk).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-  expect(second.storePk > first.storePk).toBe(true);
+  expect(first.instanceId).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+  );
+  expect(second.instanceId > first.instanceId).toBe(true);
   expect(await client.listStores(Store)).toEqual(["a", "b"]);
 
   await client.deleteStore({ definition: Store, id: "b" });
@@ -288,7 +258,7 @@ test("listStores and deleteStore manage logical store instances", async () => {
   await client.deleteStore({ definition: Store, id: "missing" });
 });
 
-test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async () => {
+test("deleteStoreFrom guards recreated stores and records the ledger first", async () => {
   const db = new Database(":memory:");
   const client = new SqliteStoreClient({
     db,
@@ -315,8 +285,8 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
   expect(versionConflict).toMatchObject({
     deleted: false,
     reason: "conflict",
-    expectedStorePk: original.storePk,
-    actualStorePk: original.storePk,
+    expectedInstanceId: original.instanceId,
+    actualInstanceId: original.instanceId,
     expectedVersion: 0,
     actualVersion: 1,
   });
@@ -344,7 +314,7 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
   ).toEqual({
     deleted: false,
     reason: "not-found",
-    expectedStorePk: current.storePk,
+    expectedInstanceId: current.instanceId,
     expectedVersion: current.version,
   });
 
@@ -353,7 +323,7 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
     id: "delete-from",
     initial: { messages: [] },
   });
-  expect(recreated.storePk).not.toBe(original.storePk);
+  expect(recreated.instanceId).not.toBe(original.instanceId);
   expect(recreated.version).toBe(0);
 
   expect(
@@ -376,8 +346,8 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
   });
   expect(staleUpdate).toMatchObject({
     updated: false,
-    expectedStorePk: original.storePk,
-    actualStorePk: recreated.storePk,
+    expectedInstanceId: original.instanceId,
+    actualInstanceId: recreated.instanceId,
     expectedVersion: 0,
     actualVersion: 0,
   });
@@ -491,7 +461,7 @@ test("a successful take wakes matching waiters", async () => {
     event: takeEvent,
     storeName: TakeStore.name,
     storeId: "take-wake",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -766,7 +736,7 @@ test("an updater that returns a replacement state wakes waiters via the diff fal
     event,
     storeName: Store.name,
     storeId: "replace",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -854,7 +824,7 @@ test("a take claim's mutations are recorded and wake matching waiters", async ()
     event,
     storeName: TakeStore.name,
     storeId: "take-wake",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages", 0, "claimedBy"]],
   });

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -151,6 +151,72 @@ test("concurrent async updaters on one client both commit", async () => {
   expect(snapshot.state.messages).toEqual([{ id: "msg-a" }, { id: "msg-b" }]);
 });
 
+test("updateStoreFrom commits only from the supplied snapshot and replays ledger-first", async () => {
+  const db = new Database(":memory:");
+  const client = new SqliteStoreClient({
+    db,
+    schedulerClient: { async requestWakeUp() {} },
+  });
+  const snapshot = await client.getOrCreateStore({
+    definition: Store,
+    id: "conditional",
+    initial: { messages: [] },
+  });
+  let updaterRuns = 0;
+  const stepId = { executionId: "execution", stepKey: "conditional-update" };
+
+  const committed = await client.updateStoreFrom({
+    definition: Store,
+    id: "conditional",
+    snapshot,
+    stepId,
+    updater(draft) {
+      updaterRuns++;
+      draft.messages.push({ id: "msg-1" });
+    },
+  });
+  expect(committed).toEqual({
+    updated: true,
+    state: { messages: [{ id: "msg-1" }] },
+    previousVersion: 0,
+    version: 1,
+  });
+
+  await client.updateStore({
+    definition: Store,
+    id: "conditional",
+    updater(draft) {
+      draft.messages.push({ id: "msg-2" });
+    },
+  });
+
+  const replayed = await client.updateStoreFrom({
+    definition: Store,
+    id: "conditional",
+    snapshot,
+    stepId,
+    updater() {
+      updaterRuns++;
+    },
+  });
+  expect(replayed).toEqual(committed);
+
+  const conflicted = await client.updateStoreFrom({
+    definition: Store,
+    id: "conditional",
+    snapshot,
+    updater() {
+      updaterRuns++;
+    },
+  });
+  expect(conflicted).toEqual({
+    updated: false,
+    expectedVersion: 0,
+    actualVersion: 2,
+  });
+  expect(updaterRuns).toBe(1);
+});
+
 type TakeState = {
   messages: { id: string; claimedBy?: string }[];
 };

--- a/packages/bun-sqlite-runtime/src/sqlite-store.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.ts
@@ -20,6 +20,7 @@ import {
   type StoreState,
   type StoreStepId,
   type StoreTakeResult,
+  type StoreUpdateFromResult,
   type StoreUpdateResult,
   type StoreWaiter,
 } from "@yieldstar/core";
@@ -163,6 +164,39 @@ export class SqliteStoreClient extends StoreClient {
     ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
     stepId?: StoreStepId;
   }): Promise<StoreUpdateResult<StoreState<Schema>>> {
+    return (await this.updateStoreInternal(params)) as StoreUpdateResult<
+      StoreState<Schema>
+    >;
+  }
+
+  async updateStoreFrom<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    snapshot: StoreSnapshot<StoreState<Schema>>;
+    updater: (
+      draft: Draft<StoreState<Schema>>
+    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    stepId?: StoreStepId;
+  }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
+    const result = await this.updateStoreInternal({
+      ...params,
+      expectedVersion: params.snapshot.version,
+    });
+    return "updated" in result ? result : { updated: true, ...result };
+  }
+
+  private updateStoreInternal<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    updater: (
+      draft: Draft<StoreState<Schema>>
+    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    stepId?: StoreStepId;
+    expectedVersion?: number;
+  }): Promise<
+    | StoreUpdateResult<StoreState<Schema>>
+    | Extract<StoreUpdateFromResult<StoreState<Schema>>, { updated: false }>
+  > {
     return this.enqueueWrite(async () => {
       let result: StoreUpdateResult<StoreState<Schema>>;
       let waitersToWake: MatchedWaiter[] = [];
@@ -191,6 +225,18 @@ export class SqliteStoreClient extends StoreClient {
           throw new Error(
             `Store "${params.definition.name}:${params.id}" does not exist`
           );
+        }
+
+        if (
+          params.expectedVersion !== undefined &&
+          row.version !== params.expectedVersion
+        ) {
+          this.db.run("COMMIT");
+          return {
+            updated: false as const,
+            expectedVersion: params.expectedVersion,
+            actualVersion: row.version,
+          };
         }
 
         const previousState = JSON.parse(row.state) as StoreState<Schema>;

--- a/packages/bun-sqlite-runtime/src/sqlite-store.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.ts
@@ -14,6 +14,7 @@ import {
   type Draft,
   type StandardSchemaV1,
   type StoreDefinition,
+  type StoreDeleteFromResult,
   type StorePath,
   type StoreSelector,
   type StoreSnapshot,
@@ -26,6 +27,7 @@ import {
 } from "@yieldstar/core";
 
 class StoreRow {
+  store_pk!: string;
   state!: string;
   version!: number;
 }
@@ -82,6 +84,7 @@ export class SqliteStoreClient extends StoreClient {
     if (existing) {
       return {
         state: JSON.parse(existing.state),
+        storePk: existing.store_pk,
         version: existing.version,
       };
     }
@@ -111,30 +114,35 @@ export class SqliteStoreClient extends StoreClient {
           this.db.run("COMMIT");
           return {
             state: JSON.parse(existingTx.state),
+            storePk: existingTx.store_pk,
             version: existingTx.version,
           };
         }
 
+        const storePk = Bun.randomUUIDv7();
         this.db
           .query(
-            `INSERT INTO stores (store_name, store_id, version, state)
-             VALUES ($storeName, $storeId, 0, $state)`
+            `INSERT INTO stores (store_pk, store_name, store_id, version, state)
+             VALUES ($storePk, $storeName, $storeId, 0, $state)`
           )
           .run({
+            $storePk: storePk,
             $storeName: params.definition.name,
             $storeId: params.id,
             $state: JSON.stringify(state),
           });
         this.db.run("COMMIT");
+        return {
+          state: cloneStoreState(state),
+          storePk,
+          version: 0,
+        };
       } catch (err) {
         this.db.run("ROLLBACK");
         throw err;
       }
 
-      return {
-        state: cloneStoreState(state),
-        version: 0,
-      };
+      throw new Error("Store creation transaction returned unexpectedly");
     });
   }
 
@@ -152,6 +160,7 @@ export class SqliteStoreClient extends StoreClient {
 
     return {
       state: JSON.parse(row.state),
+      storePk: row.store_pk,
       version: row.version,
     };
   }
@@ -180,6 +189,7 @@ export class SqliteStoreClient extends StoreClient {
   }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
     const result = await this.updateStoreInternal({
       ...params,
+      expectedStorePk: params.snapshot.storePk,
       expectedVersion: params.snapshot.version,
     });
     return "updated" in result ? result : { updated: true, ...result };
@@ -192,6 +202,7 @@ export class SqliteStoreClient extends StoreClient {
       draft: Draft<StoreState<Schema>>
     ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
     stepId?: StoreStepId;
+    expectedStorePk?: string;
     expectedVersion?: number;
   }): Promise<
     | StoreUpdateResult<StoreState<Schema>>
@@ -220,6 +231,10 @@ export class SqliteStoreClient extends StoreClient {
           }
         }
 
+        if (params.expectedVersion !== undefined) {
+          this.assertSnapshotHasStorePk({ storePk: params.expectedStorePk });
+        }
+
         const row = this.getStoreRow(params.definition.name, params.id);
         if (!row) {
           throw new Error(
@@ -228,12 +243,16 @@ export class SqliteStoreClient extends StoreClient {
         }
 
         if (
+          params.expectedStorePk !== undefined &&
           params.expectedVersion !== undefined &&
-          row.version !== params.expectedVersion
+          (row.store_pk !== params.expectedStorePk ||
+            row.version !== params.expectedVersion)
         ) {
           this.db.run("COMMIT");
           return {
             updated: false as const,
+            expectedStorePk: params.expectedStorePk,
+            actualStorePk: row.store_pk,
             expectedVersion: params.expectedVersion,
             actualVersion: row.version,
           };
@@ -263,6 +282,7 @@ export class SqliteStoreClient extends StoreClient {
         const committed = this.commitNextState({
           storeName: params.definition.name,
           storeId: params.id,
+          storePk: row.store_pk,
           changedPaths,
           nextState,
           previousVersion: row.version,
@@ -366,6 +386,7 @@ export class SqliteStoreClient extends StoreClient {
           this.db.run("COMMIT");
           return {
             matched: false,
+            storePk: row.store_pk,
             version: row.version,
             readPaths,
           };
@@ -393,6 +414,7 @@ export class SqliteStoreClient extends StoreClient {
         const committed = this.commitNextState({
           storeName: params.definition.name,
           storeId: params.id,
+          storePk: row.store_pk,
           changedPaths,
           nextState,
           previousVersion: row.version,
@@ -402,6 +424,7 @@ export class SqliteStoreClient extends StoreClient {
         result = {
           matched: true,
           selected: selectedSnapshot,
+          storePk: row.store_pk,
           version: committed.version,
         };
 
@@ -438,6 +461,7 @@ export class SqliteStoreClient extends StoreClient {
   private commitNextState(params: {
     storeName: string;
     storeId: string;
+    storePk: string;
     changedPaths: StorePath[];
     nextState: unknown;
     previousVersion: number;
@@ -449,11 +473,12 @@ export class SqliteStoreClient extends StoreClient {
       .query(
         `UPDATE stores
          SET version = $version, state = $state
-         WHERE store_name = $storeName AND store_id = $storeId`
+         WHERE store_pk = $storePk`
       )
       .run({
         $storeName: params.storeName,
         $storeId: params.storeId,
+        $storePk: params.storePk,
         $version: version,
         $state: JSON.stringify(params.nextState),
       });
@@ -526,12 +551,85 @@ export class SqliteStoreClient extends StoreClient {
             `DELETE FROM store_waiters WHERE store_name = $storeName AND store_id = $storeId`
           )
           .run(bindings);
+        this.db.run("COMMIT");
+      } catch (err) {
+        this.db.run("ROLLBACK");
+        throw err;
+      }
+    });
+  }
+
+  async deleteStoreFrom(params: {
+    definition: StoreDefinition;
+    id: string;
+    snapshot: StoreSnapshot<unknown>;
+    stepId?: StoreStepId;
+  }): Promise<StoreDeleteFromResult> {
+    return this.enqueueWrite(async () => {
+      const bindings = {
+        $storeName: params.definition.name,
+        $storeId: params.id,
+      };
+      this.db.run("BEGIN IMMEDIATE");
+      try {
+        if (params.stepId) {
+          const applied = this.getAppliedStepRow({
+            storeName: params.definition.name,
+            storeId: params.id,
+            stepId: params.stepId,
+          });
+          if (applied) {
+            this.db.run("COMMIT");
+            return JSON.parse(applied.result) as StoreDeleteFromResult;
+          }
+        }
+
+        this.assertSnapshotHasStorePk(params.snapshot);
+
+        const row = this.getStoreRow(params.definition.name, params.id);
+        if (!row) {
+          this.db.run("COMMIT");
+          return {
+            deleted: false,
+            reason: "not-found",
+            expectedStorePk: params.snapshot.storePk,
+            expectedVersion: params.snapshot.version,
+          };
+        }
+        if (
+          row.store_pk !== params.snapshot.storePk ||
+          row.version !== params.snapshot.version
+        ) {
+          this.db.run("COMMIT");
+          return {
+            deleted: false,
+            reason: "conflict",
+            expectedStorePk: params.snapshot.storePk,
+            actualStorePk: row.store_pk,
+            expectedVersion: params.snapshot.version,
+            actualVersion: row.version,
+          };
+        }
+
         this.db
           .query(
-            `DELETE FROM store_applied_steps WHERE store_name = $storeName AND store_id = $storeId`
+            `DELETE FROM store_waiters WHERE store_name = $storeName AND store_id = $storeId`
           )
           .run(bindings);
+        this.db
+          .query(`DELETE FROM stores WHERE store_pk = $storePk`)
+          .run({ $storePk: row.store_pk });
+        const result = { deleted: true as const };
+        if (params.stepId) {
+          this.insertAppliedStepRow({
+            storeName: params.definition.name,
+            storeId: params.id,
+            stepId: params.stepId,
+            result: JSON.stringify(result),
+          });
+        }
         this.db.run("COMMIT");
+        return result;
       } catch (err) {
         this.db.run("ROLLBACK");
         throw err;
@@ -574,7 +672,11 @@ export class SqliteStoreClient extends StoreClient {
         // immediate wake – the replay re-evaluates the selector, so a
         // spurious wake is safe.
         const row = this.getStoreRow(waiter.storeName, waiter.storeId);
-        if (row && row.version > waiter.sinceVersion) {
+        if (
+          !row ||
+          row.store_pk !== waiter.storePk ||
+          row.version > waiter.sinceVersion
+        ) {
           versionAdvanced = true;
         }
 
@@ -597,15 +699,24 @@ export class SqliteStoreClient extends StoreClient {
   }
 
   private setupDb() {
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS stores (
-        store_name TEXT NOT NULL,
-        store_id TEXT NOT NULL,
-        version INTEGER NOT NULL,
-        state TEXT NOT NULL,
-        PRIMARY KEY (store_name, store_id)
-      );
+    const storesTable = this.db
+      .query(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'stores'`
+      )
+      .get();
 
+    if (!storesTable) {
+      this.createStoresTable();
+    } else {
+      const columns = this.db.query(`PRAGMA table_info(stores)`).all() as Array<{
+        name: string;
+      }>;
+      if (!columns.some((column) => column.name === "store_pk")) {
+        this.migrateStoresToUuidPrimaryKey();
+      }
+    }
+
+    this.db.run(`
       CREATE TABLE IF NOT EXISTS store_waiters (
         workflow_id TEXT NOT NULL,
         execution_id TEXT NOT NULL,
@@ -627,6 +738,54 @@ export class SqliteStoreClient extends StoreClient {
         PRIMARY KEY (store_name, store_id, execution_id, step_key)
       );
     `);
+  }
+
+  private createStoresTable() {
+    this.db.run(`
+      CREATE TABLE stores (
+        store_pk TEXT PRIMARY KEY,
+        store_name TEXT NOT NULL,
+        store_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        state TEXT NOT NULL,
+        UNIQUE (store_name, store_id)
+      )
+    `);
+  }
+
+  private migrateStoresToUuidPrimaryKey() {
+    const rows = this.db.query(
+      `SELECT store_name, store_id, version, state FROM stores`
+    ).all() as Array<{
+      store_name: string;
+      store_id: string;
+      version: number;
+      state: string;
+    }>;
+
+    this.db.run("BEGIN IMMEDIATE");
+    try {
+      this.db.run(`ALTER TABLE stores RENAME TO stores_without_uuid_pk`);
+      this.createStoresTable();
+      const insert = this.db.query(`
+        INSERT INTO stores (store_pk, store_name, store_id, version, state)
+        VALUES ($storePk, $storeName, $storeId, $version, $state)
+      `);
+      for (const row of rows) {
+        insert.run({
+          $storePk: Bun.randomUUIDv7(),
+          $storeName: row.store_name,
+          $storeId: row.store_id,
+          $version: row.version,
+          $state: row.state,
+        });
+      }
+      this.db.run(`DROP TABLE stores_without_uuid_pk`);
+      this.db.run("COMMIT");
+    } catch (err) {
+      this.db.run("ROLLBACK");
+      throw err;
+    }
   }
 
   private getAppliedStepRow(params: {
@@ -676,7 +835,7 @@ export class SqliteStoreClient extends StoreClient {
   private getStoreRow(storeName: string, storeId: string) {
     return this.db
       .query(
-        `SELECT state, version FROM stores
+        `SELECT store_pk, state, version FROM stores
          WHERE store_name = $storeName AND store_id = $storeId`
       )
       .as(StoreRow)
@@ -740,6 +899,12 @@ export class SqliteStoreClient extends StoreClient {
         $executionId: params.executionId,
         $stepKey: params.stepKey,
       });
+  }
+
+  private assertSnapshotHasStorePk(snapshot: { storePk?: string }) {
+    if (!snapshot.storePk) {
+      throw new Error("Store snapshot is missing storePk; read a fresh snapshot");
+    }
   }
 }
 

--- a/packages/bun-sqlite-runtime/src/sqlite-store.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.ts
@@ -33,6 +33,10 @@ class AppliedStepRow {
   result!: string;
 }
 
+class StoreIdRow {
+  store_id!: string;
+}
+
 class WaiterRow {
   workflow_id!: string;
   execution_id!: string;
@@ -439,6 +443,54 @@ export class SqliteStoreClient extends StoreClient {
         stepKey: waiter.stepKey,
       });
     }
+  }
+
+  async listStores<Schema extends StandardSchemaV1>(
+    definition: StoreDefinition<Schema>
+  ): Promise<string[]> {
+    const rows = this.db
+      .query(
+        `SELECT store_id FROM stores
+         WHERE store_name = $storeName
+         ORDER BY store_id ASC`
+      )
+      .as(StoreIdRow)
+      .all({ $storeName: definition.name });
+    return rows.map((row) => row.store_id);
+  }
+
+  async deleteStore<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+  }): Promise<void> {
+    return this.enqueueWrite(async () => {
+      const bindings = {
+        $storeName: params.definition.name,
+        $storeId: params.id,
+      };
+      this.db.run("BEGIN IMMEDIATE");
+      try {
+        this.db
+          .query(
+            `DELETE FROM stores WHERE store_name = $storeName AND store_id = $storeId`
+          )
+          .run(bindings);
+        this.db
+          .query(
+            `DELETE FROM store_waiters WHERE store_name = $storeName AND store_id = $storeId`
+          )
+          .run(bindings);
+        this.db
+          .query(
+            `DELETE FROM store_applied_steps WHERE store_name = $storeName AND store_id = $storeId`
+          )
+          .run(bindings);
+        this.db.run("COMMIT");
+      } catch (err) {
+        this.db.run("ROLLBACK");
+        throw err;
+      }
+    });
   }
 
   async registerWaiter(waiter: StoreWaiter): Promise<void> {

--- a/packages/bun-sqlite-runtime/src/sqlite-store.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.ts
@@ -27,7 +27,7 @@ import {
 } from "@yieldstar/core";
 
 class StoreRow {
-  store_pk!: string;
+  instance_id!: string;
   state!: string;
   version!: number;
 }
@@ -84,7 +84,7 @@ export class SqliteStoreClient extends StoreClient {
     if (existing) {
       return {
         state: JSON.parse(existing.state),
-        storePk: existing.store_pk,
+        instanceId: existing.instance_id,
         version: existing.version,
       };
     }
@@ -114,19 +114,19 @@ export class SqliteStoreClient extends StoreClient {
           this.db.run("COMMIT");
           return {
             state: JSON.parse(existingTx.state),
-            storePk: existingTx.store_pk,
+            instanceId: existingTx.instance_id,
             version: existingTx.version,
           };
         }
 
-        const storePk = Bun.randomUUIDv7();
+        const instanceId = Bun.randomUUIDv7();
         this.db
           .query(
-            `INSERT INTO stores (store_pk, store_name, store_id, version, state)
-             VALUES ($storePk, $storeName, $storeId, 0, $state)`
+            `INSERT INTO stores (instance_id, store_name, store_id, version, state)
+             VALUES ($instanceId, $storeName, $storeId, 0, $state)`
           )
           .run({
-            $storePk: storePk,
+            $instanceId: instanceId,
             $storeName: params.definition.name,
             $storeId: params.id,
             $state: JSON.stringify(state),
@@ -134,7 +134,7 @@ export class SqliteStoreClient extends StoreClient {
         this.db.run("COMMIT");
         return {
           state: cloneStoreState(state),
-          storePk,
+          instanceId,
           version: 0,
         };
       } catch (err) {
@@ -160,7 +160,7 @@ export class SqliteStoreClient extends StoreClient {
 
     return {
       state: JSON.parse(row.state),
-      storePk: row.store_pk,
+      instanceId: row.instance_id,
       version: row.version,
     };
   }
@@ -189,7 +189,7 @@ export class SqliteStoreClient extends StoreClient {
   }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
     const result = await this.updateStoreInternal({
       ...params,
-      expectedStorePk: params.snapshot.storePk,
+      expectedInstanceId: params.snapshot.instanceId,
       expectedVersion: params.snapshot.version,
     });
     return "updated" in result ? result : { updated: true, ...result };
@@ -202,7 +202,7 @@ export class SqliteStoreClient extends StoreClient {
       draft: Draft<StoreState<Schema>>
     ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
     stepId?: StoreStepId;
-    expectedStorePk?: string;
+    expectedInstanceId?: string;
     expectedVersion?: number;
   }): Promise<
     | StoreUpdateResult<StoreState<Schema>>
@@ -232,7 +232,9 @@ export class SqliteStoreClient extends StoreClient {
         }
 
         if (params.expectedVersion !== undefined) {
-          this.assertSnapshotHasStorePk({ storePk: params.expectedStorePk });
+          this.assertSnapshotHasInstanceId({
+            instanceId: params.expectedInstanceId,
+          });
         }
 
         const row = this.getStoreRow(params.definition.name, params.id);
@@ -243,16 +245,16 @@ export class SqliteStoreClient extends StoreClient {
         }
 
         if (
-          params.expectedStorePk !== undefined &&
+          params.expectedInstanceId !== undefined &&
           params.expectedVersion !== undefined &&
-          (row.store_pk !== params.expectedStorePk ||
+          (row.instance_id !== params.expectedInstanceId ||
             row.version !== params.expectedVersion)
         ) {
           this.db.run("COMMIT");
           return {
             updated: false as const,
-            expectedStorePk: params.expectedStorePk,
-            actualStorePk: row.store_pk,
+            expectedInstanceId: params.expectedInstanceId,
+            actualInstanceId: row.instance_id,
             expectedVersion: params.expectedVersion,
             actualVersion: row.version,
           };
@@ -282,7 +284,7 @@ export class SqliteStoreClient extends StoreClient {
         const committed = this.commitNextState({
           storeName: params.definition.name,
           storeId: params.id,
-          storePk: row.store_pk,
+          instanceId: row.instance_id,
           changedPaths,
           nextState,
           previousVersion: row.version,
@@ -386,7 +388,7 @@ export class SqliteStoreClient extends StoreClient {
           this.db.run("COMMIT");
           return {
             matched: false,
-            storePk: row.store_pk,
+            instanceId: row.instance_id,
             version: row.version,
             readPaths,
           };
@@ -414,7 +416,7 @@ export class SqliteStoreClient extends StoreClient {
         const committed = this.commitNextState({
           storeName: params.definition.name,
           storeId: params.id,
-          storePk: row.store_pk,
+          instanceId: row.instance_id,
           changedPaths,
           nextState,
           previousVersion: row.version,
@@ -424,7 +426,7 @@ export class SqliteStoreClient extends StoreClient {
         result = {
           matched: true,
           selected: selectedSnapshot,
-          storePk: row.store_pk,
+          instanceId: row.instance_id,
           version: committed.version,
         };
 
@@ -461,7 +463,7 @@ export class SqliteStoreClient extends StoreClient {
   private commitNextState(params: {
     storeName: string;
     storeId: string;
-    storePk: string;
+    instanceId: string;
     changedPaths: StorePath[];
     nextState: unknown;
     previousVersion: number;
@@ -473,12 +475,12 @@ export class SqliteStoreClient extends StoreClient {
       .query(
         `UPDATE stores
          SET version = $version, state = $state
-         WHERE store_pk = $storePk`
+         WHERE instance_id = $instanceId`
       )
       .run({
         $storeName: params.storeName,
         $storeId: params.storeId,
-        $storePk: params.storePk,
+        $instanceId: params.instanceId,
         $version: version,
         $state: JSON.stringify(params.nextState),
       });
@@ -584,7 +586,7 @@ export class SqliteStoreClient extends StoreClient {
           }
         }
 
-        this.assertSnapshotHasStorePk(params.snapshot);
+        this.assertSnapshotHasInstanceId(params.snapshot);
 
         const row = this.getStoreRow(params.definition.name, params.id);
         if (!row) {
@@ -592,20 +594,20 @@ export class SqliteStoreClient extends StoreClient {
           return {
             deleted: false,
             reason: "not-found",
-            expectedStorePk: params.snapshot.storePk,
+            expectedInstanceId: params.snapshot.instanceId,
             expectedVersion: params.snapshot.version,
           };
         }
         if (
-          row.store_pk !== params.snapshot.storePk ||
+          row.instance_id !== params.snapshot.instanceId ||
           row.version !== params.snapshot.version
         ) {
           this.db.run("COMMIT");
           return {
             deleted: false,
             reason: "conflict",
-            expectedStorePk: params.snapshot.storePk,
-            actualStorePk: row.store_pk,
+            expectedInstanceId: params.snapshot.instanceId,
+            actualInstanceId: row.instance_id,
             expectedVersion: params.snapshot.version,
             actualVersion: row.version,
           };
@@ -617,8 +619,8 @@ export class SqliteStoreClient extends StoreClient {
           )
           .run(bindings);
         this.db
-          .query(`DELETE FROM stores WHERE store_pk = $storePk`)
-          .run({ $storePk: row.store_pk });
+          .query(`DELETE FROM stores WHERE instance_id = $instanceId`)
+          .run({ $instanceId: row.instance_id });
         const result = { deleted: true as const };
         if (params.stepId) {
           this.insertAppliedStepRow({
@@ -674,7 +676,7 @@ export class SqliteStoreClient extends StoreClient {
         const row = this.getStoreRow(waiter.storeName, waiter.storeId);
         if (
           !row ||
-          row.store_pk !== waiter.storePk ||
+          row.instance_id !== waiter.instanceId ||
           row.version > waiter.sinceVersion
         ) {
           versionAdvanced = true;
@@ -699,22 +701,7 @@ export class SqliteStoreClient extends StoreClient {
   }
 
   private setupDb() {
-    const storesTable = this.db
-      .query(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'stores'`
-      )
-      .get();
-
-    if (!storesTable) {
-      this.createStoresTable();
-    } else {
-      const columns = this.db.query(`PRAGMA table_info(stores)`).all() as Array<{
-        name: string;
-      }>;
-      if (!columns.some((column) => column.name === "store_pk")) {
-        this.migrateStoresToUuidPrimaryKey();
-      }
-    }
+    this.createStoresTable();
 
     this.db.run(`
       CREATE TABLE IF NOT EXISTS store_waiters (
@@ -742,8 +729,8 @@ export class SqliteStoreClient extends StoreClient {
 
   private createStoresTable() {
     this.db.run(`
-      CREATE TABLE stores (
-        store_pk TEXT PRIMARY KEY,
+      CREATE TABLE IF NOT EXISTS stores (
+        instance_id TEXT PRIMARY KEY,
         store_name TEXT NOT NULL,
         store_id TEXT NOT NULL,
         version INTEGER NOT NULL,
@@ -751,41 +738,6 @@ export class SqliteStoreClient extends StoreClient {
         UNIQUE (store_name, store_id)
       )
     `);
-  }
-
-  private migrateStoresToUuidPrimaryKey() {
-    const rows = this.db.query(
-      `SELECT store_name, store_id, version, state FROM stores`
-    ).all() as Array<{
-      store_name: string;
-      store_id: string;
-      version: number;
-      state: string;
-    }>;
-
-    this.db.run("BEGIN IMMEDIATE");
-    try {
-      this.db.run(`ALTER TABLE stores RENAME TO stores_without_uuid_pk`);
-      this.createStoresTable();
-      const insert = this.db.query(`
-        INSERT INTO stores (store_pk, store_name, store_id, version, state)
-        VALUES ($storePk, $storeName, $storeId, $version, $state)
-      `);
-      for (const row of rows) {
-        insert.run({
-          $storePk: Bun.randomUUIDv7(),
-          $storeName: row.store_name,
-          $storeId: row.store_id,
-          $version: row.version,
-          $state: row.state,
-        });
-      }
-      this.db.run(`DROP TABLE stores_without_uuid_pk`);
-      this.db.run("COMMIT");
-    } catch (err) {
-      this.db.run("ROLLBACK");
-      throw err;
-    }
   }
 
   private getAppliedStepRow(params: {
@@ -835,7 +787,7 @@ export class SqliteStoreClient extends StoreClient {
   private getStoreRow(storeName: string, storeId: string) {
     return this.db
       .query(
-        `SELECT store_pk, state, version FROM stores
+        `SELECT instance_id, state, version FROM stores
          WHERE store_name = $storeName AND store_id = $storeId`
       )
       .as(StoreRow)
@@ -901,9 +853,11 @@ export class SqliteStoreClient extends StoreClient {
       });
   }
 
-  private assertSnapshotHasStorePk(snapshot: { storePk?: string }) {
-    if (!snapshot.storePk) {
-      throw new Error("Store snapshot is missing storePk; read a fresh snapshot");
+  private assertSnapshotHasInstanceId(snapshot: { instanceId?: string }) {
+    if (!snapshot.instanceId) {
+      throw new Error(
+        "Store snapshot is missing instanceId; read a fresh snapshot"
+      );
     }
   }
 }

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -68,7 +68,7 @@ export type StoreStepId = {
 
 export type StoreSnapshot<T> = {
   state: T;
-  storePk: string;
+  instanceId: string;
   version: StoreVersion;
 };
 
@@ -82,8 +82,8 @@ export type StoreUpdateFromResult<T> =
   | ({ updated: true } & StoreUpdateResult<T>)
   | {
       updated: false;
-      expectedStorePk: string;
-      actualStorePk: string;
+      expectedInstanceId: string;
+      actualInstanceId: string;
       expectedVersion: StoreVersion;
       actualVersion: StoreVersion;
     };
@@ -93,15 +93,15 @@ export type StoreDeleteFromResult =
   | {
       deleted: false;
       reason: "conflict";
-      expectedStorePk: string;
-      actualStorePk: string;
+      expectedInstanceId: string;
+      actualInstanceId: string;
       expectedVersion: StoreVersion;
       actualVersion: StoreVersion;
     }
   | {
       deleted: false;
       reason: "not-found";
-      expectedStorePk: string;
+      expectedInstanceId: string;
       expectedVersion: StoreVersion;
     };
 
@@ -111,12 +111,12 @@ export type StoreTakeResult<R> =
   | {
       matched: true;
       selected: NonNullable<R>;
-      storePk: string;
+      instanceId: string;
       version: StoreVersion;
     }
   | {
       matched: false;
-      storePk: string;
+      instanceId: string;
       version: StoreVersion;
       readPaths: StorePath[];
     };
@@ -128,7 +128,7 @@ export type StoreWaiter = {
   event: WorkflowEvent;
   storeName: string;
   storeId: string;
-  storePk: string;
+  instanceId: string;
   sinceVersion: StoreVersion;
   readPaths: StorePath[];
 };
@@ -283,7 +283,7 @@ export abstract class StoreClient {
     id: string;
   }): Promise<void>;
 
-  /** Deletes a store only if it is still the supplied snapshot incarnation and version. */
+  /** Deletes a store only if its instance ID and version still match the snapshot. */
   abstract deleteStoreFrom(params: {
     definition: StoreDefinition;
     id: string;

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -68,6 +68,7 @@ export type StoreStepId = {
 
 export type StoreSnapshot<T> = {
   state: T;
+  storePk: string;
   version: StoreVersion;
 };
 
@@ -81,15 +82,44 @@ export type StoreUpdateFromResult<T> =
   | ({ updated: true } & StoreUpdateResult<T>)
   | {
       updated: false;
+      expectedStorePk: string;
+      actualStorePk: string;
       expectedVersion: StoreVersion;
       actualVersion: StoreVersion;
+    };
+
+export type StoreDeleteFromResult =
+  | { deleted: true }
+  | {
+      deleted: false;
+      reason: "conflict";
+      expectedStorePk: string;
+      actualStorePk: string;
+      expectedVersion: StoreVersion;
+      actualVersion: StoreVersion;
+    }
+  | {
+      deleted: false;
+      reason: "not-found";
+      expectedStorePk: string;
+      expectedVersion: StoreVersion;
     };
 
 export type StoreSelector<T, R> = (state: Readonly<T>) => R;
 
 export type StoreTakeResult<R> =
-  | { matched: true; selected: NonNullable<R>; version: StoreVersion }
-  | { matched: false; version: StoreVersion; readPaths: StorePath[] };
+  | {
+      matched: true;
+      selected: NonNullable<R>;
+      storePk: string;
+      version: StoreVersion;
+    }
+  | {
+      matched: false;
+      storePk: string;
+      version: StoreVersion;
+      readPaths: StorePath[];
+    };
 
 export type StoreWaiter = {
   workflowId: string;
@@ -98,6 +128,7 @@ export type StoreWaiter = {
   event: WorkflowEvent;
   storeName: string;
   storeId: string;
+  storePk: string;
   sinceVersion: StoreVersion;
   readPaths: StorePath[];
 };
@@ -111,6 +142,7 @@ export type RuntimeStore<T> = {
     snapshot: StoreSnapshot<T>,
     updater: (draft: Draft<T>) => void | T | Promise<void | T>
   ): Promise<StoreUpdateFromResult<T>>;
+  deleteFrom(snapshot: StoreSnapshot<T>): Promise<StoreDeleteFromResult>;
 };
 
 export function defineStore<Schema extends StandardSchemaV1>(
@@ -143,6 +175,12 @@ export abstract class StoreClient {
           id,
           snapshot,
           updater,
+        }),
+      deleteFrom: (snapshot) =>
+        this.deleteStoreFrom({
+          definition,
+          id,
+          snapshot,
         }),
     };
   }
@@ -244,6 +282,14 @@ export abstract class StoreClient {
     definition: StoreDefinition;
     id: string;
   }): Promise<void>;
+
+  /** Deletes a store only if it is still the supplied snapshot incarnation and version. */
+  abstract deleteStoreFrom(params: {
+    definition: StoreDefinition;
+    id: string;
+    snapshot: StoreSnapshot<unknown>;
+    stepId?: StoreStepId;
+  }): Promise<StoreDeleteFromResult>;
 }
 
 export function isStoreSelectorMatch<R>(

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -192,6 +192,23 @@ export abstract class StoreClient {
   }): Promise<StoreTakeResult<R>>;
 
   abstract registerWaiter(waiter: StoreWaiter): Promise<void>;
+
+  /**
+   * Enumerates the ids of every store created under a given definition name.
+   * Needed by external consumers (e.g. Notation's state backend) that treat a
+   * store name as a collection of instances and must list them. Order is
+   * ascending by id so callers get a deterministic sequence.
+   */
+  abstract listStores(definition: StoreDefinition): Promise<string[]>;
+
+  /**
+   * Removes a store instance and all of its associated rows (state, waiters,
+   * applied-steps ledger). A no-op if the store does not exist.
+   */
+  abstract deleteStore(params: {
+    definition: StoreDefinition;
+    id: string;
+  }): Promise<void>;
 }
 
 export function isStoreSelectorMatch<R>(

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -17,9 +17,13 @@ export type StandardSchemaV1<Input = unknown, Output = Input> = {
 };
 
 export namespace StandardSchemaV1 {
+  export type PathSegment = {
+    readonly key: PropertyKey;
+  };
+
   export type Issue = {
     readonly message: string;
-    readonly path?: readonly PropertyKey[];
+    readonly path?: readonly (PropertyKey | PathSegment)[];
   };
 
   export type Result<Output> =

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -77,6 +77,14 @@ export type StoreUpdateResult<T> = {
   version: StoreVersion;
 };
 
+export type StoreUpdateFromResult<T> =
+  | ({ updated: true } & StoreUpdateResult<T>)
+  | {
+      updated: false;
+      expectedVersion: StoreVersion;
+      actualVersion: StoreVersion;
+    };
+
 export type StoreSelector<T, R> = (state: Readonly<T>) => R;
 
 export type StoreTakeResult<R> =
@@ -99,6 +107,10 @@ export type RuntimeStore<T> = {
   update(
     updater: (draft: Draft<T>) => void | T | Promise<void | T>
   ): Promise<StoreUpdateResult<T>>;
+  updateFrom(
+    snapshot: StoreSnapshot<T>,
+    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+  ): Promise<StoreUpdateFromResult<T>>;
 };
 
 export function defineStore<Schema extends StandardSchemaV1>(
@@ -123,6 +135,13 @@ export abstract class StoreClient {
         this.updateStore({
           definition,
           id,
+          updater,
+        }),
+      updateFrom: (snapshot, updater) =>
+        this.updateStoreFrom({
+          definition,
+          id,
+          snapshot,
           updater,
         }),
     };
@@ -161,6 +180,22 @@ export abstract class StoreClient {
     ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
     stepId?: StoreStepId;
   }): Promise<StoreUpdateResult<StoreState<Schema>>>;
+
+  /**
+   * Updates a store only if it has not changed since `snapshot` was read.
+   * A conflict does not run the updater or change the store. When `stepId`
+   * identifies an update that already committed, its recorded result wins
+   * over the version check so replay remains exactly-once.
+   */
+  abstract updateStoreFrom<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    snapshot: StoreSnapshot<StoreState<Schema>>;
+    updater: (
+      draft: Draft<StoreState<Schema>>
+    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    stepId?: StoreStepId;
+  }): Promise<StoreUpdateFromResult<StoreState<Schema>>>;
 
   /**
    * Atomically selects and claims from a store. The selector and claim

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type {
   StoreState,
   StoreStepId,
   StoreTakeResult,
+  StoreUpdateFromResult,
   StoreUpdateResult,
   StoreVersion,
   StoreWaiter,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export type {
   RuntimeStore,
   StandardSchemaV1,
   StoreDefinition,
+  StoreDeleteFromResult,
   StoreKey,
   StorePath,
   StoreSelector,

--- a/packages/test-runtime/src/memory-store.test.ts
+++ b/packages/test-runtime/src/memory-store.test.ts
@@ -138,6 +138,68 @@ test("concurrent async updaters both commit", async () => {
   expect(snapshot.state.messages).toEqual([{ id: "msg-a" }, { id: "msg-b" }]);
 });
 
+test("updateStoreFrom commits only from the supplied snapshot and replays ledger-first", async () => {
+  const { client } = createClient();
+  const snapshot = await client.getOrCreateStore({
+    definition: Store,
+    id: "conditional",
+    initial: { messages: [] },
+  });
+  let updaterRuns = 0;
+  const stepId = { executionId: "execution", stepKey: "conditional-update" };
+
+  const committed = await client.updateStoreFrom({
+    definition: Store,
+    id: "conditional",
+    snapshot,
+    stepId,
+    updater(draft) {
+      updaterRuns++;
+      draft.messages.push({ id: "msg-1" });
+    },
+  });
+  expect(committed).toEqual({
+    updated: true,
+    state: { messages: [{ id: "msg-1" }] },
+    previousVersion: 0,
+    version: 1,
+  });
+
+  await client.updateStore({
+    definition: Store,
+    id: "conditional",
+    updater(draft) {
+      draft.messages.push({ id: "msg-2" });
+    },
+  });
+
+  const replayed = await client.updateStoreFrom({
+    definition: Store,
+    id: "conditional",
+    snapshot,
+    stepId,
+    updater() {
+      updaterRuns++;
+    },
+  });
+  expect(replayed).toEqual(committed);
+
+  const conflicted = await client.updateStoreFrom({
+    definition: Store,
+    id: "conditional",
+    snapshot,
+    updater() {
+      updaterRuns++;
+    },
+  });
+  expect(conflicted).toEqual({
+    updated: false,
+    expectedVersion: 0,
+    actualVersion: 2,
+  });
+  expect(updaterRuns).toBe(1);
+});
+
 type TakeState = {
   messages: { id: string; claimedBy?: string }[];
 };

--- a/packages/test-runtime/src/memory-store.test.ts
+++ b/packages/test-runtime/src/memory-store.test.ts
@@ -34,7 +34,7 @@ const event = {
 test("memory store updates wake matching waiters", async () => {
   const { client, events } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "one",
     initial: { messages: [] },
@@ -46,6 +46,7 @@ test("memory store updates wake matching waiters", async () => {
     event,
     storeName: Store.name,
     storeId: "one",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -63,7 +64,7 @@ test("memory store updates wake matching waiters", async () => {
 test("registering a waiter with a stale sinceVersion triggers an immediate wake", async () => {
   const { client, events } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "stale",
     initial: { messages: [] },
@@ -85,6 +86,7 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
     event,
     storeName: Store.name,
     storeId: "stale",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -176,7 +178,7 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   const replayed = await client.updateStoreFrom({
     definition: Store,
     id: "conditional",
-    snapshot,
+    snapshot: { ...snapshot, storePk: "" },
     stepId,
     updater() {
       updaterRuns++;
@@ -194,10 +196,136 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   });
   expect(conflicted).toEqual({
     updated: false,
+    expectedStorePk: snapshot.storePk,
+    actualStorePk: snapshot.storePk,
     expectedVersion: 0,
     actualVersion: 2,
   });
   expect(updaterRuns).toBe(1);
+});
+
+test("listStores and deleteStore manage logical store instances", async () => {
+  const { client } = createClient();
+  const OtherStore = defineStore("memory-test-other", schema<State>());
+  const first = await client.getOrCreateStore({
+    definition: Store,
+    id: "b",
+    initial: { messages: [] },
+  });
+  const second = await client.getOrCreateStore({
+    definition: Store,
+    id: "a",
+    initial: { messages: [] },
+  });
+  await client.getOrCreateStore({
+    definition: OtherStore,
+    id: "a",
+    initial: { messages: [] },
+  });
+
+  expect(first.storePk).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  expect(second.storePk > first.storePk).toBe(true);
+  expect(await client.listStores(Store)).toEqual(["a", "b"]);
+
+  await client.deleteStore({ definition: Store, id: "b" });
+  expect(await client.listStores(Store)).toEqual(["a"]);
+  expect(client.getStore({ definition: Store, id: "b" })).rejects.toThrow(
+    'Store "memory-test:b" does not exist'
+  );
+  await client.deleteStore({ definition: Store, id: "missing" });
+});
+
+test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async () => {
+  const { client } = createClient();
+  const original = await client.getOrCreateStore({
+    definition: Store,
+    id: "delete-from",
+    initial: { messages: [] },
+  });
+  await client.updateStore({
+    definition: Store,
+    id: "delete-from",
+    updater(draft) {
+      draft.messages.push({ id: "changed" });
+    },
+  });
+
+  const versionConflict = await client.deleteStoreFrom({
+    definition: Store,
+    id: "delete-from",
+    snapshot: original,
+  });
+  expect(versionConflict).toMatchObject({
+    deleted: false,
+    reason: "conflict",
+    expectedStorePk: original.storePk,
+    actualStorePk: original.storePk,
+    expectedVersion: 0,
+    actualVersion: 1,
+  });
+
+  const current = await client.getStore({
+    definition: Store,
+    id: "delete-from",
+  });
+  const stepId = { executionId: "execution", stepKey: "delete" };
+  expect(
+    await client.deleteStoreFrom({
+      definition: Store,
+      id: "delete-from",
+      snapshot: current,
+      stepId,
+    })
+  ).toEqual({ deleted: true });
+
+  expect(
+    await client.deleteStoreFrom({
+      definition: Store,
+      id: "delete-from",
+      snapshot: current,
+    })
+  ).toEqual({
+    deleted: false,
+    reason: "not-found",
+    expectedStorePk: current.storePk,
+    expectedVersion: current.version,
+  });
+
+  const recreated = await client.getOrCreateStore({
+    definition: Store,
+    id: "delete-from",
+    initial: { messages: [] },
+  });
+  expect(recreated.storePk).not.toBe(original.storePk);
+  expect(recreated.version).toBe(0);
+
+  // A replay returns the old committed deletion and leaves the new
+  // incarnation untouched.
+  expect(
+    await client.deleteStoreFrom({
+      definition: Store,
+      id: "delete-from",
+      snapshot: current,
+      stepId,
+    })
+  ).toEqual({ deleted: true });
+  expect(
+    await client.getStore({ definition: Store, id: "delete-from" })
+  ).toEqual(recreated);
+
+  const staleUpdate = await client.updateStoreFrom({
+    definition: Store,
+    id: "delete-from",
+    snapshot: original,
+    updater() {},
+  });
+  expect(staleUpdate).toMatchObject({
+    updated: false,
+    expectedStorePk: original.storePk,
+    actualStorePk: recreated.storePk,
+    expectedVersion: 0,
+    actualVersion: 0,
+  });
 });
 
 type TakeState = {
@@ -209,7 +337,7 @@ const TakeStore = defineStore("memory-take-test", schema<TakeState>());
 test("concurrent takers claim distinct items", async () => {
   const { client } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-race",
     initial: { messages: [{ id: "msg-1" }, { id: "msg-2" }] },
@@ -278,7 +406,7 @@ test("take returns readPaths and version when the selector misses", async () => 
 test("a successful take wakes matching waiters", async () => {
   const { client, events } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-wake",
     initial: { messages: [{ id: "msg-1" }] },
@@ -290,6 +418,7 @@ test("a successful take wakes matching waiters", async () => {
     event,
     storeName: TakeStore.name,
     storeId: "take-wake",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -309,7 +438,7 @@ test("a successful take wakes matching waiters", async () => {
 test("take rejects async claims without committing", async () => {
   const { client } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-async",
     initial: { messages: [{ id: "msg-1" }] },
@@ -539,7 +668,7 @@ test("ledger entries are scoped per execution and step key", async () => {
 test("an updater that returns a replacement state wakes waiters via the diff fallback", async () => {
   const { client, events } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "replace",
     initial: { messages: [] },
@@ -551,6 +680,7 @@ test("an updater that returns a replacement state wakes waiters via the diff fal
     event,
     storeName: Store.name,
     storeId: "replace",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -581,7 +711,7 @@ test("mutating updates derive changed paths from recorded writes, not a full-sta
   const messages = Array.from({ length: 5000 }, (_, i) => ({
     id: `msg-${i}`,
   }));
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "large",
     initial: { messages },
@@ -593,6 +723,7 @@ test("mutating updates derive changed paths from recorded writes, not a full-sta
     event,
     storeName: Store.name,
     storeId: "large",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -626,7 +757,7 @@ test("mutating updates derive changed paths from recorded writes, not a full-sta
 test("committed state is proxy-free and structuredClone-able", async () => {
   const { client } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: Store,
     id: "laundered",
     initial: { messages: [{ id: "msg-1" }] },
@@ -656,7 +787,7 @@ test("committed state is proxy-free and structuredClone-able", async () => {
 test("a take claim that splices the array wakes waiters on shifted indices", async () => {
   const { client, events } = createClient();
 
-  await client.getOrCreateStore({
+  const initial = await client.getOrCreateStore({
     definition: TakeStore,
     id: "take-splice",
     initial: { messages: [{ id: "msg-1" }, { id: "msg-2" }] },
@@ -668,6 +799,7 @@ test("a take claim that splices the array wakes waiters on shifted indices", asy
     event,
     storeName: TakeStore.name,
     storeId: "take-splice",
+    storePk: initial.storePk,
     sinceVersion: 0,
     readPaths: [["messages", 0, "id"]],
   });

--- a/packages/test-runtime/src/memory-store.test.ts
+++ b/packages/test-runtime/src/memory-store.test.ts
@@ -46,7 +46,7 @@ test("memory store updates wake matching waiters", async () => {
     event,
     storeName: Store.name,
     storeId: "one",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -86,7 +86,7 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
     event,
     storeName: Store.name,
     storeId: "stale",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -178,7 +178,7 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   const replayed = await client.updateStoreFrom({
     definition: Store,
     id: "conditional",
-    snapshot: { ...snapshot, storePk: "" },
+    snapshot: { ...snapshot, instanceId: "" },
     stepId,
     updater() {
       updaterRuns++;
@@ -196,8 +196,8 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   });
   expect(conflicted).toEqual({
     updated: false,
-    expectedStorePk: snapshot.storePk,
-    actualStorePk: snapshot.storePk,
+    expectedInstanceId: snapshot.instanceId,
+    actualInstanceId: snapshot.instanceId,
     expectedVersion: 0,
     actualVersion: 2,
   });
@@ -223,8 +223,10 @@ test("listStores and deleteStore manage logical store instances", async () => {
     initial: { messages: [] },
   });
 
-  expect(first.storePk).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-  expect(second.storePk > first.storePk).toBe(true);
+  expect(first.instanceId).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+  );
+  expect(second.instanceId > first.instanceId).toBe(true);
   expect(await client.listStores(Store)).toEqual(["a", "b"]);
 
   await client.deleteStore({ definition: Store, id: "b" });
@@ -235,7 +237,7 @@ test("listStores and deleteStore manage logical store instances", async () => {
   await client.deleteStore({ definition: Store, id: "missing" });
 });
 
-test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async () => {
+test("deleteStoreFrom guards recreated stores and records the ledger first", async () => {
   const { client } = createClient();
   const original = await client.getOrCreateStore({
     definition: Store,
@@ -258,8 +260,8 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
   expect(versionConflict).toMatchObject({
     deleted: false,
     reason: "conflict",
-    expectedStorePk: original.storePk,
-    actualStorePk: original.storePk,
+    expectedInstanceId: original.instanceId,
+    actualInstanceId: original.instanceId,
     expectedVersion: 0,
     actualVersion: 1,
   });
@@ -287,7 +289,7 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
   ).toEqual({
     deleted: false,
     reason: "not-found",
-    expectedStorePk: current.storePk,
+    expectedInstanceId: current.instanceId,
     expectedVersion: current.version,
   });
 
@@ -296,11 +298,11 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
     id: "delete-from",
     initial: { messages: [] },
   });
-  expect(recreated.storePk).not.toBe(original.storePk);
+  expect(recreated.instanceId).not.toBe(original.instanceId);
   expect(recreated.version).toBe(0);
 
   // A replay returns the old committed deletion and leaves the new
-  // incarnation untouched.
+  // instance untouched.
   expect(
     await client.deleteStoreFrom({
       definition: Store,
@@ -321,8 +323,8 @@ test("deleteStoreFrom is conditional, incarnation-safe, and ledger-first", async
   });
   expect(staleUpdate).toMatchObject({
     updated: false,
-    expectedStorePk: original.storePk,
-    actualStorePk: recreated.storePk,
+    expectedInstanceId: original.instanceId,
+    actualInstanceId: recreated.instanceId,
     expectedVersion: 0,
     actualVersion: 0,
   });
@@ -418,7 +420,7 @@ test("a successful take wakes matching waiters", async () => {
     event,
     storeName: TakeStore.name,
     storeId: "take-wake",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -680,7 +682,7 @@ test("an updater that returns a replacement state wakes waiters via the diff fal
     event,
     storeName: Store.name,
     storeId: "replace",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -723,7 +725,7 @@ test("mutating updates derive changed paths from recorded writes, not a full-sta
     event,
     storeName: Store.name,
     storeId: "large",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages"]],
   });
@@ -799,7 +801,7 @@ test("a take claim that splices the array wakes waiters on shifted indices", asy
     event,
     storeName: TakeStore.name,
     storeId: "take-splice",
-    storePk: initial.storePk,
+    instanceId: initial.instanceId,
     sinceVersion: 0,
     readPaths: [["messages", 0, "id"]],
   });

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -27,7 +27,7 @@ import {
 
 type StoreRecord = {
   state: unknown;
-  storePk: string;
+  instanceId: string;
   version: number;
 };
 
@@ -68,7 +68,7 @@ export class MemoryStoreClient extends StoreClient {
     if (existing) {
       return {
         state: cloneStoreState(existing.state) as StoreState<Schema>,
-        storePk: existing.storePk,
+        instanceId: existing.instanceId,
         version: existing.version,
       };
     }
@@ -90,16 +90,16 @@ export class MemoryStoreClient extends StoreClient {
         : initialValue;
     const state = await validateStoreState(params.definition, initial);
 
-    const storePk = Bun.randomUUIDv7();
+    const instanceId = Bun.randomUUIDv7();
     this.stores.set(key, {
       state: cloneStoreState(state),
-      storePk,
+      instanceId,
       version: 0,
     });
 
     return {
       state: cloneStoreState(state),
-      storePk,
+      instanceId,
       version: 0,
     };
   }
@@ -120,7 +120,7 @@ export class MemoryStoreClient extends StoreClient {
 
     return {
       state: cloneStoreState(record.state) as StoreState<Schema>,
-      storePk: record.storePk,
+      instanceId: record.instanceId,
       version: record.version,
     };
   }
@@ -149,7 +149,7 @@ export class MemoryStoreClient extends StoreClient {
   }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
     const result = await this.updateStoreInternal({
       ...params,
-      expectedStorePk: params.snapshot.storePk,
+      expectedInstanceId: params.snapshot.instanceId,
       expectedVersion: params.snapshot.version,
     });
     return "updated" in result ? result : { updated: true, ...result };
@@ -162,7 +162,7 @@ export class MemoryStoreClient extends StoreClient {
       draft: Draft<StoreState<Schema>>
     ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
     stepId?: StoreStepId;
-    expectedStorePk?: string;
+    expectedInstanceId?: string;
     expectedVersion?: number;
   }): Promise<
     | StoreUpdateResult<StoreState<Schema>>
@@ -183,7 +183,9 @@ export class MemoryStoreClient extends StoreClient {
       }
 
       if (params.expectedVersion !== undefined) {
-        this.assertSnapshotHasStorePk({ storePk: params.expectedStorePk });
+        this.assertSnapshotHasInstanceId({
+          instanceId: params.expectedInstanceId,
+        });
       }
 
       const record = this.stores.get(key);
@@ -194,15 +196,15 @@ export class MemoryStoreClient extends StoreClient {
       }
 
       if (
-        params.expectedStorePk !== undefined &&
+        params.expectedInstanceId !== undefined &&
         params.expectedVersion !== undefined &&
-        (record.storePk !== params.expectedStorePk ||
+        (record.instanceId !== params.expectedInstanceId ||
           record.version !== params.expectedVersion)
       ) {
         return {
           updated: false as const,
-          expectedStorePk: params.expectedStorePk,
-          actualStorePk: record.storePk,
+          expectedInstanceId: params.expectedInstanceId,
+          actualInstanceId: record.instanceId,
           expectedVersion: params.expectedVersion,
           actualVersion: record.version,
         };
@@ -235,7 +237,7 @@ export class MemoryStoreClient extends StoreClient {
         key,
         storeName: params.definition.name,
         storeId: params.id,
-        storePk: record.storePk,
+        instanceId: record.instanceId,
         changedPaths,
         nextState,
         previousVersion: record.version,
@@ -319,7 +321,7 @@ export class MemoryStoreClient extends StoreClient {
       if (!isStoreSelectorMatch(selectedResult)) {
         return {
           matched: false,
-          storePk: record.storePk,
+          instanceId: record.instanceId,
           version: record.version,
           readPaths,
         };
@@ -346,7 +348,7 @@ export class MemoryStoreClient extends StoreClient {
         key,
         storeName: params.definition.name,
         storeId: params.id,
-        storePk: record.storePk,
+        instanceId: record.instanceId,
         changedPaths,
         nextState,
         previousVersion: record.version,
@@ -361,7 +363,7 @@ export class MemoryStoreClient extends StoreClient {
               result: JSON.stringify({
                 matched: true,
                 selected: selectedSnapshot,
-                storePk: record.storePk,
+                instanceId: record.instanceId,
                 version: record.version + 1,
               }),
             }
@@ -371,7 +373,7 @@ export class MemoryStoreClient extends StoreClient {
       return {
         matched: true,
         selected: selectedSnapshot,
-        storePk: record.storePk,
+        instanceId: record.instanceId,
         version,
       };
     });
@@ -385,7 +387,7 @@ export class MemoryStoreClient extends StoreClient {
     key: string;
     storeName: string;
     storeId: string;
-    storePk: string;
+    instanceId: string;
     changedPaths: StorePath[];
     nextState: unknown;
     previousVersion: number;
@@ -396,7 +398,7 @@ export class MemoryStoreClient extends StoreClient {
 
     this.stores.set(params.key, {
       state: cloneStoreState(params.nextState),
-      storePk: params.storePk,
+      instanceId: params.instanceId,
       version,
     });
 
@@ -460,7 +462,7 @@ export class MemoryStoreClient extends StoreClient {
         if (applied) return JSON.parse(applied) as StoreDeleteFromResult;
       }
 
-      this.assertSnapshotHasStorePk(params.snapshot);
+      this.assertSnapshotHasInstanceId(params.snapshot);
 
       const key = this.storeKey(params.definition.name, params.id);
       const record = this.stores.get(key);
@@ -468,19 +470,19 @@ export class MemoryStoreClient extends StoreClient {
         return {
           deleted: false,
           reason: "not-found",
-          expectedStorePk: params.snapshot.storePk,
+          expectedInstanceId: params.snapshot.instanceId,
           expectedVersion: params.snapshot.version,
         };
       }
       if (
-        record.storePk !== params.snapshot.storePk ||
+        record.instanceId !== params.snapshot.instanceId ||
         record.version !== params.snapshot.version
       ) {
         return {
           deleted: false,
           reason: "conflict",
-          expectedStorePk: params.snapshot.storePk,
-          actualStorePk: record.storePk,
+          expectedInstanceId: params.snapshot.instanceId,
+          actualInstanceId: record.instanceId,
           expectedVersion: params.snapshot.version,
           actualVersion: record.version,
         };
@@ -488,7 +490,7 @@ export class MemoryStoreClient extends StoreClient {
 
       this.stores.delete(key);
       for (const [waiterKey, waiter] of [...this.waiters.entries()]) {
-        if (waiter.storePk === record.storePk) this.waiters.delete(waiterKey);
+        if (waiter.instanceId === record.instanceId) this.waiters.delete(waiterKey);
       }
       const result = { deleted: true as const };
       if (ledgerKey) this.appliedSteps.set(ledgerKey, JSON.stringify(result));
@@ -513,7 +515,7 @@ export class MemoryStoreClient extends StoreClient {
       );
       if (
         !record ||
-        record.storePk !== waiter.storePk ||
+        record.instanceId !== waiter.instanceId ||
         record.version > waiter.sinceVersion
       ) {
         await this.schedulerClient.requestWakeUp(waiter.event);
@@ -568,9 +570,11 @@ export class MemoryStoreClient extends StoreClient {
     return `${storeName}:${storeId}:${executionId}:${stepKey}`;
   }
 
-  private assertSnapshotHasStorePk(snapshot: { storePk?: string }) {
-    if (!snapshot.storePk) {
-      throw new Error("Store snapshot is missing storePk; read a fresh snapshot");
+  private assertSnapshotHasInstanceId(snapshot: { instanceId?: string }) {
+    if (!snapshot.instanceId) {
+      throw new Error(
+        "Store snapshot is missing instanceId; read a fresh snapshot"
+      );
     }
   }
 }

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -346,6 +346,36 @@ export class MemoryStoreClient extends StoreClient {
     return version;
   }
 
+  async listStores<Schema extends StandardSchemaV1>(
+    definition: StoreDefinition<Schema>
+  ): Promise<string[]> {
+    const prefix = `${definition.name}:`;
+    const ids: string[] = [];
+    for (const key of this.stores.keys()) {
+      if (key.startsWith(prefix)) ids.push(key.slice(prefix.length));
+    }
+    return ids.sort();
+  }
+
+  async deleteStore<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+  }): Promise<void> {
+    return this.enqueueWrite(async () => {
+      const { name } = params.definition;
+      this.stores.delete(this.storeKey(name, params.id));
+      for (const [key, waiter] of [...this.waiters.entries()]) {
+        if (waiter.storeName === name && waiter.storeId === params.id) {
+          this.waiters.delete(key);
+        }
+      }
+      const ledgerPrefix = `[${JSON.stringify(name)},${JSON.stringify(params.id)},`;
+      for (const key of [...this.appliedSteps.keys()]) {
+        if (key.startsWith(ledgerPrefix)) this.appliedSteps.delete(key);
+      }
+    });
+  }
+
   async registerWaiter(waiter: StoreWaiter): Promise<void> {
     return this.enqueueWrite(async () => {
       const key = this.waiterKey(

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -13,6 +13,7 @@ import {
   type Draft,
   type StandardSchemaV1,
   type StoreDefinition,
+  type StoreDeleteFromResult,
   type StorePath,
   type StoreSelector,
   type StoreSnapshot,
@@ -26,6 +27,7 @@ import {
 
 type StoreRecord = {
   state: unknown;
+  storePk: string;
   version: number;
 };
 
@@ -66,6 +68,7 @@ export class MemoryStoreClient extends StoreClient {
     if (existing) {
       return {
         state: cloneStoreState(existing.state) as StoreState<Schema>,
+        storePk: existing.storePk,
         version: existing.version,
       };
     }
@@ -87,13 +90,16 @@ export class MemoryStoreClient extends StoreClient {
         : initialValue;
     const state = await validateStoreState(params.definition, initial);
 
+    const storePk = Bun.randomUUIDv7();
     this.stores.set(key, {
       state: cloneStoreState(state),
+      storePk,
       version: 0,
     });
 
     return {
       state: cloneStoreState(state),
+      storePk,
       version: 0,
     };
   }
@@ -114,6 +120,7 @@ export class MemoryStoreClient extends StoreClient {
 
     return {
       state: cloneStoreState(record.state) as StoreState<Schema>,
+      storePk: record.storePk,
       version: record.version,
     };
   }
@@ -142,6 +149,7 @@ export class MemoryStoreClient extends StoreClient {
   }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
     const result = await this.updateStoreInternal({
       ...params,
+      expectedStorePk: params.snapshot.storePk,
       expectedVersion: params.snapshot.version,
     });
     return "updated" in result ? result : { updated: true, ...result };
@@ -154,6 +162,7 @@ export class MemoryStoreClient extends StoreClient {
       draft: Draft<StoreState<Schema>>
     ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
     stepId?: StoreStepId;
+    expectedStorePk?: string;
     expectedVersion?: number;
   }): Promise<
     | StoreUpdateResult<StoreState<Schema>>
@@ -173,6 +182,10 @@ export class MemoryStoreClient extends StoreClient {
         }
       }
 
+      if (params.expectedVersion !== undefined) {
+        this.assertSnapshotHasStorePk({ storePk: params.expectedStorePk });
+      }
+
       const record = this.stores.get(key);
       if (!record) {
         throw new Error(
@@ -181,11 +194,15 @@ export class MemoryStoreClient extends StoreClient {
       }
 
       if (
+        params.expectedStorePk !== undefined &&
         params.expectedVersion !== undefined &&
-        record.version !== params.expectedVersion
+        (record.storePk !== params.expectedStorePk ||
+          record.version !== params.expectedVersion)
       ) {
         return {
           updated: false as const,
+          expectedStorePk: params.expectedStorePk,
+          actualStorePk: record.storePk,
           expectedVersion: params.expectedVersion,
           actualVersion: record.version,
         };
@@ -218,6 +235,7 @@ export class MemoryStoreClient extends StoreClient {
         key,
         storeName: params.definition.name,
         storeId: params.id,
+        storePk: record.storePk,
         changedPaths,
         nextState,
         previousVersion: record.version,
@@ -301,6 +319,7 @@ export class MemoryStoreClient extends StoreClient {
       if (!isStoreSelectorMatch(selectedResult)) {
         return {
           matched: false,
+          storePk: record.storePk,
           version: record.version,
           readPaths,
         };
@@ -327,6 +346,7 @@ export class MemoryStoreClient extends StoreClient {
         key,
         storeName: params.definition.name,
         storeId: params.id,
+        storePk: record.storePk,
         changedPaths,
         nextState,
         previousVersion: record.version,
@@ -341,6 +361,7 @@ export class MemoryStoreClient extends StoreClient {
               result: JSON.stringify({
                 matched: true,
                 selected: selectedSnapshot,
+                storePk: record.storePk,
                 version: record.version + 1,
               }),
             }
@@ -350,6 +371,7 @@ export class MemoryStoreClient extends StoreClient {
       return {
         matched: true,
         selected: selectedSnapshot,
+        storePk: record.storePk,
         version,
       };
     });
@@ -363,6 +385,7 @@ export class MemoryStoreClient extends StoreClient {
     key: string;
     storeName: string;
     storeId: string;
+    storePk: string;
     changedPaths: StorePath[];
     nextState: unknown;
     previousVersion: number;
@@ -373,6 +396,7 @@ export class MemoryStoreClient extends StoreClient {
 
     this.stores.set(params.key, {
       state: cloneStoreState(params.nextState),
+      storePk: params.storePk,
       version,
     });
 
@@ -414,10 +438,61 @@ export class MemoryStoreClient extends StoreClient {
           this.waiters.delete(key);
         }
       }
-      const ledgerPrefix = `[${JSON.stringify(name)},${JSON.stringify(params.id)},`;
-      for (const key of [...this.appliedSteps.keys()]) {
-        if (key.startsWith(ledgerPrefix)) this.appliedSteps.delete(key);
+    });
+  }
+
+  async deleteStoreFrom(params: {
+    definition: StoreDefinition;
+    id: string;
+    snapshot: StoreSnapshot<unknown>;
+    stepId?: StoreStepId;
+  }): Promise<StoreDeleteFromResult> {
+    return this.enqueueWrite(async () => {
+      const ledgerKey = params.stepId
+        ? this.appliedStepKey(
+            params.definition.name,
+            params.id,
+            params.stepId
+          )
+        : undefined;
+      if (ledgerKey) {
+        const applied = this.appliedSteps.get(ledgerKey);
+        if (applied) return JSON.parse(applied) as StoreDeleteFromResult;
       }
+
+      this.assertSnapshotHasStorePk(params.snapshot);
+
+      const key = this.storeKey(params.definition.name, params.id);
+      const record = this.stores.get(key);
+      if (!record) {
+        return {
+          deleted: false,
+          reason: "not-found",
+          expectedStorePk: params.snapshot.storePk,
+          expectedVersion: params.snapshot.version,
+        };
+      }
+      if (
+        record.storePk !== params.snapshot.storePk ||
+        record.version !== params.snapshot.version
+      ) {
+        return {
+          deleted: false,
+          reason: "conflict",
+          expectedStorePk: params.snapshot.storePk,
+          actualStorePk: record.storePk,
+          expectedVersion: params.snapshot.version,
+          actualVersion: record.version,
+        };
+      }
+
+      this.stores.delete(key);
+      for (const [waiterKey, waiter] of [...this.waiters.entries()]) {
+        if (waiter.storePk === record.storePk) this.waiters.delete(waiterKey);
+      }
+      const result = { deleted: true as const };
+      if (ledgerKey) this.appliedSteps.set(ledgerKey, JSON.stringify(result));
+      return result;
     });
   }
 
@@ -429,8 +504,6 @@ export class MemoryStoreClient extends StoreClient {
         waiter.executionId,
         waiter.stepKey
       );
-      this.waiters.set(key, cloneStoreState(waiter));
-
       // Lost-wakeup guard: if an update landed between the caller's getStore
       // and this registration, the version has already advanced. Wake
       // immediately – replay re-evaluates the selector, so a spurious wake
@@ -438,10 +511,15 @@ export class MemoryStoreClient extends StoreClient {
       const record = this.stores.get(
         this.storeKey(waiter.storeName, waiter.storeId)
       );
-      if (record && record.version > waiter.sinceVersion) {
-        this.waiters.delete(key);
+      if (
+        !record ||
+        record.storePk !== waiter.storePk ||
+        record.version > waiter.sinceVersion
+      ) {
         await this.schedulerClient.requestWakeUp(waiter.event);
+        return;
       }
+      this.waiters.set(key, cloneStoreState(waiter));
     });
   }
 
@@ -488,5 +566,11 @@ export class MemoryStoreClient extends StoreClient {
     stepKey: string
   ) {
     return `${storeName}:${storeId}:${executionId}:${stepKey}`;
+  }
+
+  private assertSnapshotHasStorePk(snapshot: { storePk?: string }) {
+    if (!snapshot.storePk) {
+      throw new Error("Store snapshot is missing storePk; read a fresh snapshot");
+    }
   }
 }

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -19,6 +19,7 @@ import {
   type StoreState,
   type StoreStepId,
   type StoreTakeResult,
+  type StoreUpdateFromResult,
   type StoreUpdateResult,
   type StoreWaiter,
 } from "@yieldstar/core";
@@ -125,6 +126,39 @@ export class MemoryStoreClient extends StoreClient {
     ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
     stepId?: StoreStepId;
   }): Promise<StoreUpdateResult<StoreState<Schema>>> {
+    return (await this.updateStoreInternal(params)) as StoreUpdateResult<
+      StoreState<Schema>
+    >;
+  }
+
+  async updateStoreFrom<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    snapshot: StoreSnapshot<StoreState<Schema>>;
+    updater: (
+      draft: Draft<StoreState<Schema>>
+    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    stepId?: StoreStepId;
+  }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
+    const result = await this.updateStoreInternal({
+      ...params,
+      expectedVersion: params.snapshot.version,
+    });
+    return "updated" in result ? result : { updated: true, ...result };
+  }
+
+  private updateStoreInternal<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    updater: (
+      draft: Draft<StoreState<Schema>>
+    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    stepId?: StoreStepId;
+    expectedVersion?: number;
+  }): Promise<
+    | StoreUpdateResult<StoreState<Schema>>
+    | Extract<StoreUpdateFromResult<StoreState<Schema>>, { updated: false }>
+  > {
     return this.enqueueWrite(async () => {
       const key = this.storeKey(params.definition.name, params.id);
 
@@ -144,6 +178,17 @@ export class MemoryStoreClient extends StoreClient {
         throw new Error(
           `Store "${params.definition.name}:${params.id}" does not exist`
         );
+      }
+
+      if (
+        params.expectedVersion !== undefined &&
+        record.version !== params.expectedVersion
+      ) {
+        return {
+          updated: false as const,
+          expectedVersion: params.expectedVersion,
+          actualVersion: record.version,
+        };
       }
 
       const previousState = cloneStoreState(

--- a/packages/test-utils/src/workflow-runner.ts
+++ b/packages/test-utils/src/workflow-runner.ts
@@ -23,9 +23,10 @@ export function createTestSdkFactory(params?: { logger?: Logger }) {
     const memoryEventLoop = new MemoryEventLoop(logger);
     const schedulerClient = new MemorySchedulerClient(memoryEventLoop);
     const storeClient = new MemoryStoreClient({ schedulerClient });
+    const heapClient = new MemoryHeapClient();
 
     const workflowRunner = new WorkflowRunner({
-      heapClient: new MemoryHeapClient(),
+      heapClient,
       schedulerClient,
       storeClient,
       router: workflowRouter,
@@ -69,6 +70,7 @@ export function createTestSdkFactory(params?: { logger?: Logger }) {
       },
       store: storeClient.store.bind(storeClient),
       storeClient,
+      heapClient,
     };
   };
 }

--- a/packages/yieldstar/src/index.ts
+++ b/packages/yieldstar/src/index.ts
@@ -16,6 +16,7 @@ export type {
   StoreSelector,
   StoreSnapshot,
   StoreState,
+  StoreUpdateFromResult,
   StoreUpdateResult,
   StoreVersion,
 } from "@yieldstar/core";

--- a/packages/yieldstar/src/index.ts
+++ b/packages/yieldstar/src/index.ts
@@ -11,6 +11,7 @@ export type {
   RuntimeStore,
   StandardSchemaV1,
   StoreDefinition,
+  StoreDeleteFromResult,
   StoreKey,
   StorePath,
   StoreSelector,

--- a/packages/yieldstar/src/index.ts
+++ b/packages/yieldstar/src/index.ts
@@ -20,4 +20,5 @@ export type {
   StoreUpdateFromResult,
   StoreUpdateResult,
   StoreVersion,
+  WorkflowEvent,
 } from "@yieldstar/core";

--- a/packages/yieldstar/src/internal/step-runner.ts
+++ b/packages/yieldstar/src/internal/step-runner.ts
@@ -17,6 +17,7 @@ import {
   type StoreSnapshot,
   type StoreState,
   type StoreTakeResult,
+  type StoreUpdateFromResult,
   type StoreUpdateResult,
   trackStoreSelector,
 } from "@yieldstar/core";
@@ -47,6 +48,11 @@ export type WorkflowStore<T> = {
     key: string,
     updater: (draft: Draft<T>) => void | T | Promise<void | T>
   ): AsyncGenerator<StepResponse, StoreUpdateResult<T>>;
+  updateFrom(
+    key: string,
+    snapshot: StoreSnapshot<T>,
+    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+  ): AsyncGenerator<StepResponse, StoreUpdateFromResult<T>>;
   when<R>(
     selector: StoreSelector<T, R | undefined | null | false>
   ): AsyncGenerator<StepResponse, NonNullable<R>>;
@@ -184,6 +190,17 @@ function createWorkflowStore<T>(params: {
           // recorded result instead of re-running the updater.
           stepId: { executionId: event.executionId, stepKey },
         })) as StoreUpdateResult<T>
+      );
+    },
+    updateFrom(stepKey, snapshot, updater) {
+      return durableStep<StoreUpdateFromResult<T>>(stepKey, async () =>
+        (await storeClient.updateStoreFrom({
+          definition,
+          id,
+          snapshot,
+          updater: updater as any,
+          stepId: { executionId: event.executionId, stepKey },
+        })) as StoreUpdateFromResult<T>
       );
     },
     when<R>(

--- a/packages/yieldstar/src/internal/step-runner.ts
+++ b/packages/yieldstar/src/internal/step-runner.ts
@@ -442,7 +442,7 @@ async function* whenStep<T, R>(params: {
     event,
     storeName: definition.name,
     storeId: id,
-    storePk: snapshot.storePk,
+    instanceId: snapshot.instanceId,
     sinceVersion: snapshot.version,
     readPaths,
   });
@@ -506,7 +506,7 @@ async function* takeStep<T, R>(params: {
     event,
     storeName: definition.name,
     storeId: id,
-    storePk: outcome.storePk,
+    instanceId: outcome.instanceId,
     sinceVersion: outcome.version,
     readPaths: outcome.readPaths,
   });

--- a/packages/yieldstar/src/internal/step-runner.ts
+++ b/packages/yieldstar/src/internal/step-runner.ts
@@ -12,6 +12,7 @@ import {
   StepStoreWait,
   type StoreClient,
   type StoreDefinition,
+  type StoreDeleteFromResult,
   type StoreKey,
   type StoreSelector,
   type StoreSnapshot,
@@ -53,6 +54,10 @@ export type WorkflowStore<T> = {
     snapshot: StoreSnapshot<T>,
     updater: (draft: Draft<T>) => void | T | Promise<void | T>
   ): AsyncGenerator<StepResponse, StoreUpdateFromResult<T>>;
+  deleteFrom(
+    key: string,
+    snapshot: StoreSnapshot<T>
+  ): AsyncGenerator<StepResponse, StoreDeleteFromResult>;
   when<R>(
     selector: StoreSelector<T, R | undefined | null | false>
   ): AsyncGenerator<StepResponse, NonNullable<R>>;
@@ -201,6 +206,16 @@ function createWorkflowStore<T>(params: {
           updater: updater as any,
           stepId: { executionId: event.executionId, stepKey },
         })) as StoreUpdateFromResult<T>
+      );
+    },
+    deleteFrom(stepKey, snapshot) {
+      return durableStep<StoreDeleteFromResult>(stepKey, () =>
+        storeClient.deleteStoreFrom({
+          definition,
+          id,
+          snapshot,
+          stepId: { executionId: event.executionId, stepKey },
+        })
       );
     },
     when<R>(
@@ -427,6 +442,7 @@ async function* whenStep<T, R>(params: {
     event,
     storeName: definition.name,
     storeId: id,
+    storePk: snapshot.storePk,
     sinceVersion: snapshot.version,
     readPaths,
   });
@@ -490,6 +506,7 @@ async function* takeStep<T, R>(params: {
     event,
     storeName: definition.name,
     storeId: id,
+    storePk: outcome.storePk,
     sinceVersion: outcome.version,
     readPaths: outcome.readPaths,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       pino:
         specifier: ^9.9.0
         version: 9.9.0
+      valibot:
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@5.9.2)
       yieldstar:
         specifier: workspace:*
         version: link:../packages/yieldstar
@@ -560,6 +563,14 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -960,6 +971,10 @@ snapshots:
   undici-types@7.10.0: {}
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.4.2(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
 
   wcwidth@1.0.1:
     dependencies:

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -95,6 +95,33 @@ test("workflow store updates are idempotent across replay", async () => {
   ]);
 });
 
+test("workflow stores can conditionally update from a snapshot", async () => {
+  const testWorkflow = workflow(async function* (step) {
+    const store = yield* step.store(ConversationStore, {
+      id: "conditional",
+      initial: { messages: [], status: "idle" },
+    });
+    const snapshot = yield* store.get("snapshot");
+
+    yield* store.update("intervening-update", (draft) => {
+      draft.status = "working";
+    });
+
+    return yield* store.updateFrom("conditional-update", snapshot, (draft) => {
+      draft.status = "idle";
+    });
+  });
+
+  const sdk = createSdk({ workflow: testWorkflow });
+  const result = await sdk.triggerAndWait({ workflowId: "workflow" });
+
+  expect(result).toEqual({
+    updated: false,
+    expectedVersion: 0,
+    actualVersion: 1,
+  });
+});
+
 test("external store updates wake when waiters", async () => {
   const testWorkflow = workflow(async function* (step) {
     const store = yield* step.store(ConversationStore, {
@@ -679,6 +706,82 @@ test("store update converges exactly-once when the heap write is lost", async ()
   expect(snapshot.version).toBe(1);
   expect(snapshot.state.messages).toEqual([
     { id: "msg-1", content: "hello", processed: false },
+  ]);
+});
+
+test("updateFrom replay returns its committed result after the store advances", async () => {
+  let updaterRuns = 0;
+  let originalSnapshot: {
+    state: ConversationState;
+    version: number;
+  };
+
+  const testWorkflow = workflow(async function* (step) {
+    const store = yield* step.store(ConversationStore, {
+      id: "conditional-crash-gap",
+    });
+
+    return yield* store.updateFrom(
+      "persist-from-snapshot",
+      originalSnapshot,
+      (draft) => {
+        updaterRuns++;
+        draft.status = "working";
+      }
+    );
+  });
+
+  const sdk = createSdk({ workflow: testWorkflow });
+  originalSnapshot = await sdk.storeClient.getOrCreateStore({
+    definition: ConversationStore,
+    id: "conditional-crash-gap",
+    initial: { messages: [], status: "idle" },
+  });
+
+  // Simulate the conditional store commit succeeding before the workflow
+  // heap records the step result.
+  const committed = await sdk.storeClient.updateStoreFrom({
+    definition: ConversationStore,
+    id: "conditional-crash-gap",
+    snapshot: originalSnapshot,
+    updater(draft) {
+      draft.status = "working";
+    },
+    stepId: {
+      executionId: "conditional-crash-replay",
+      stepKey: "persist-from-snapshot",
+    },
+  });
+
+  // The original snapshot is now stale. Ledger-first replay must still return
+  // the committed result rather than report a conflict or run the updater.
+  await sdk.storeClient.updateStore({
+    definition: ConversationStore,
+    id: "conditional-crash-gap",
+    updater(draft) {
+      draft.messages.push({
+        id: "msg-after",
+        content: "later",
+        processed: false,
+      });
+    },
+  });
+
+  const replayed = await sdk.triggerAndWait({
+    workflowId: "workflow",
+    executionId: "conditional-crash-replay",
+  });
+
+  expect(replayed).toEqual(committed);
+  expect(replayed.updated).toBe(true);
+  expect(updaterRuns).toBe(0);
+
+  const current = await sdk
+    .store(ConversationStore, "conditional-crash-gap")
+    .get();
+  expect(current.version).toBe(2);
+  expect(current.state.messages).toEqual([
+    { id: "msg-after", content: "later", processed: false },
   ]);
 });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -55,7 +55,7 @@ test("workflow stores can be created, read, and updated", async () => {
     state: { messages: [], status: "idle" },
     version: 0,
   });
-  expect(result.initial.storePk).toMatch(/^[0-9a-f-]+$/);
+  expect(result.initial.instanceId).toMatch(/^[0-9a-f-]+$/);
   expect(result.update.previousVersion).toBe(0);
   expect(result.update.version).toBe(1);
   expect(result.current).toEqual({
@@ -63,7 +63,7 @@ test("workflow stores can be created, read, and updated", async () => {
       messages: [{ id: "msg-1", content: "hello", processed: false }],
       status: "idle",
     },
-    storePk: result.initial.storePk,
+    instanceId: result.initial.instanceId,
     version: 1,
   });
 });
@@ -123,7 +123,7 @@ test("workflow stores can conditionally update from a snapshot", async () => {
     actualVersion: 1,
   });
   if (result.updated) throw new Error("update should conflict");
-  expect(result.actualStorePk).toBe(result.expectedStorePk);
+  expect(result.actualInstanceId).toBe(result.expectedInstanceId);
 });
 
 test("external store updates wake when waiters", async () => {
@@ -717,7 +717,7 @@ test("updateFrom replay returns its committed result after the store advances", 
   let updaterRuns = 0;
   let originalSnapshot: {
     state: ConversationState;
-    storePk: string;
+    instanceId: string;
     version: number;
   };
 
@@ -790,7 +790,7 @@ test("updateFrom replay returns its committed result after the store advances", 
   ]);
 });
 
-test("deleteFrom replay returns its committed result without deleting a new incarnation", async () => {
+test("deleteFrom replay returns its committed result without deleting a new instance", async () => {
   const executionId = "delete-crash-replay";
   const storeId = "delete-crash-gap";
   const testWorkflow = workflow(async function* (step) {
@@ -840,7 +840,7 @@ test("deleteFrom replay returns its committed result without deleting a new inca
     id: storeId,
     initial: { messages: [], status: "working" },
   });
-  expect(recreated.storePk).not.toBe(snapshot.storePk);
+  expect(recreated.instanceId).not.toBe(snapshot.instanceId);
 
   const replayed = await sdk.triggerAndWait({
     workflowId: "workflow",

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -51,10 +51,11 @@ test("workflow stores can be created, read, and updated", async () => {
   const sdk = createSdk({ workflow: testWorkflow });
   const result = await sdk.triggerAndWait({ workflowId: "workflow" });
 
-  expect(result.initial).toEqual({
+  expect(result.initial).toMatchObject({
     state: { messages: [], status: "idle" },
     version: 0,
   });
+  expect(result.initial.storePk).toMatch(/^[0-9a-f-]+$/);
   expect(result.update.previousVersion).toBe(0);
   expect(result.update.version).toBe(1);
   expect(result.current).toEqual({
@@ -62,6 +63,7 @@ test("workflow stores can be created, read, and updated", async () => {
       messages: [{ id: "msg-1", content: "hello", processed: false }],
       status: "idle",
     },
+    storePk: result.initial.storePk,
     version: 1,
   });
 });
@@ -115,11 +117,13 @@ test("workflow stores can conditionally update from a snapshot", async () => {
   const sdk = createSdk({ workflow: testWorkflow });
   const result = await sdk.triggerAndWait({ workflowId: "workflow" });
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     updated: false,
     expectedVersion: 0,
     actualVersion: 1,
   });
+  if (result.updated) throw new Error("update should conflict");
+  expect(result.actualStorePk).toBe(result.expectedStorePk);
 });
 
 test("external store updates wake when waiters", async () => {
@@ -713,6 +717,7 @@ test("updateFrom replay returns its committed result after the store advances", 
   let updaterRuns = 0;
   let originalSnapshot: {
     state: ConversationState;
+    storePk: string;
     version: number;
   };
 
@@ -783,6 +788,69 @@ test("updateFrom replay returns its committed result after the store advances", 
   expect(current.state.messages).toEqual([
     { id: "msg-after", content: "later", processed: false },
   ]);
+});
+
+test("deleteFrom replay returns its committed result without deleting a new incarnation", async () => {
+  const executionId = "delete-crash-replay";
+  const storeId = "delete-crash-gap";
+  const testWorkflow = workflow(async function* (step) {
+    const store = yield* step.store(ConversationStore, { id: storeId });
+    const snapshot = yield* store.get("delete-snapshot");
+    return yield* store.deleteFrom("delete-store", snapshot);
+  });
+  const sdk = createSdk({ workflow: testWorkflow });
+  const snapshot = await sdk.storeClient.getOrCreateStore({
+    definition: ConversationStore,
+    id: storeId,
+    initial: { messages: [], status: "idle" },
+  });
+
+  // These earlier workflow steps were durably recorded before the deletion.
+  await sdk.heapClient.writeStep({
+    executionId,
+    stepKey: `store:${ConversationStore.name}:${storeId}`,
+    stepAttempt: 0,
+    stepDone: true,
+    stepResponseJson: JSON.stringify({
+      type: "step-result",
+      result: { storeName: ConversationStore.name, storeId },
+    }),
+  });
+  await sdk.heapClient.writeStep({
+    executionId,
+    stepKey: "delete-snapshot",
+    stepAttempt: 0,
+    stepDone: true,
+    stepResponseJson: JSON.stringify({
+      type: "step-result",
+      result: snapshot,
+    }),
+  });
+
+  const committed = await sdk.storeClient.deleteStoreFrom({
+    definition: ConversationStore,
+    id: storeId,
+    snapshot,
+    stepId: { executionId, stepKey: "delete-store" },
+  });
+  expect(committed).toEqual({ deleted: true });
+
+  const recreated = await sdk.storeClient.getOrCreateStore({
+    definition: ConversationStore,
+    id: storeId,
+    initial: { messages: [], status: "working" },
+  });
+  expect(recreated.storePk).not.toBe(snapshot.storePk);
+
+  const replayed = await sdk.triggerAndWait({
+    workflowId: "workflow",
+    executionId,
+  });
+  expect(replayed).toEqual({ deleted: true });
+  expect(await sdk.storeClient.getStore({
+    definition: ConversationStore,
+    id: storeId,
+  })).toEqual(recreated);
 });
 
 function schema<T>(): StandardSchemaV1<unknown, T> {


### PR DESCRIPTION
This adds durable workflow stores across the core API, workflow SDK, in-memory runtime and SQLite runtime. The API is still being shaped through review.

## What changed

- Add store creation, reads, updates, selection, waiting and atomic claims.
- Add snapshot-based updates and deletions.
- Assign each created store a UUIDv7 `instanceId`.
- Compare the instance ID and version before a snapshot-based write.
- Add store listing and administrative deletion.
- Record committed workflow operations so replay returns the original result.
- Add an example workflow in `examples/workflows/store.ts`.
- Document the workflow and runtime APIs.

## Why instance IDs exist

A logical store is identified by its definition and ID. Its version resets when the store is deleted and recreated.

A version check alone could therefore accept a snapshot from an earlier store whose version happens to match. The instance ID changes on recreation, so comparing both values rejects that stale snapshot.

## Deliberate omissions

There is no SQLite migration path. Stores have not been used in production, so the runtime creates the current schema directly.

## Validation

- `bun test` – 103 passed, 1 skipped, 0 failed
- `bun dts`
- `bun run bundle`
- `git diff --check`
