### PR TITLE
Make store protocol CAS-ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@
 
 ### Breaking changes
 
-- Store updater callbacks are now synchronous. `update` and `updateFrom` no
-  longer accept promise-returning updaters; callbacks must also be deterministic
-  and side-effect-free because a CAS conflict may run them again.
+- Store updater callbacks must be synchronous and side-effect-free. `update`
+  and `updateFrom` do not accept promise-returning callbacks because concurrent
+  writes may cause an updater to run more than once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+### Breaking changes
+
+- Store updater callbacks are now synchronous. `update` and `updateFrom` no
+  longer accept promise-returning updaters; callbacks must also be deterministic
+  and side-effect-free because a CAS conflict may run them again.

--- a/SPEC.md
+++ b/SPEC.md
@@ -278,12 +278,13 @@ yield* store.update(`start:${message.id}`, draft => {
 
 `update` is a durable step. The key is the workflow step key for that update.
 
-Updaters are synchronous, deterministic, and side-effect-free. A CAS conflict
-may run the updater again against a newer snapshot before it commits.
+Updaters are synchronous, deterministic, and side-effect-free. Stores commit
+with compare-and-swap (CAS): if the version changed after the read, the runtime
+runs the updater again against the latest snapshot.
 
 If replayed, the workflow step cache returns the recorded `StoreUpdateResult` and the runtime does not call the store updater again. This holds even when the previous run crashed after the store commit but before the workflow heap write, because the store itself records the committed result in the applied-steps ledger (see below) inside the same transaction as the state change.
 
-Public `paths` are not accepted. The runtime derives changed paths from the update itself: the updater runs against a write-recording proxy over the draft, and every `set`/`deleteProperty` through the proxy records its full path (mutating array methods are captured naturally via the index/length writes they perform). This makes path derivation O(changes) rather than O(state size). If the updater returns a replacement state instead of mutating the draft, the runtime falls back to deep-diffing the previous and next states. Changed paths only affect wake precision, never state correctness, so ambiguous operations are recorded conservatively – an extra path is at worst a spurious wake, which replay absorbs.
+The runtime derives changed paths automatically. The updater runs against a write-recording proxy over the draft, and every `set`/`deleteProperty` through the proxy records its full path (mutating array methods are captured naturally via the index/length writes they perform). This makes path derivation O(changes) rather than O(state size). If the updater returns a replacement state instead of mutating the draft, the runtime falls back to deep-diffing the previous and next states. Changed paths only affect wake precision, never state correctness, so ambiguous operations are recorded conservatively – an extra path is at worst a spurious wake, which replay absorbs.
 
 Update semantics:
 
@@ -292,9 +293,12 @@ Update semantics:
 - The updated state is validated against the store schema before commit.
 - The update result records `previousVersion` and `version`.
 - The runtime records changed paths internally for waiter wakeups.
-- A rejected update does not prove that its mutation rolled back: wake delivery
-  can fail after the state commit. Retrying is exactly-once only with the same
-  workflow `stepId`; external callers must read and reconcile before retrying.
+- Durable connectors record matching wake intents atomically with the state
+  change. Scheduler delivery happens after commit and is best-effort: a failed
+  delivery remains pending and does not reject the committed update.
+- A connector response can be lost after commit. Workflow calls are
+  exactly-once through their `stepId`; direct callers must read and reconcile
+  before retrying an ambiguous failure.
 
 ## `when`
 
@@ -337,7 +341,11 @@ The selector is not serialized. The runtime wakes coarsely from stored read path
 
 ## `take`
 
-`take` is the atomic wait-and-consume primitive. It atomically selects and claims: the selector and the claim mutation run inside the SAME store update transaction, committing as one version bump. This is the primitive for multi-consumer mailboxes and queues where exactly one execution must win each item; `when` remains the pure observe primitive.
+`take` is the atomic wait-and-consume primitive. It selects and claims from a
+snapshot, then conditionally commits the claim as one version bump. If the
+snapshot is stale, selection and claiming restart from the latest state. This
+is the primitive for multi-consumer mailboxes and queues where exactly one
+execution must win each item; `when` remains the pure observe primitive.
 
 ```ts
 const msg = yield* store.take(

--- a/SPEC.md
+++ b/SPEC.md
@@ -189,13 +189,13 @@ interface WorkflowStore<T> {
 
   update(
     key: string,
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+    updater: (draft: Draft<T>) => void | T
   ): AsyncGenerator<StepResponse, StoreUpdateResult<T>>
 
   updateFrom(
     key: string,
     snapshot: StoreSnapshot<T>,
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+    updater: (draft: Draft<T>) => void | T
   ): AsyncGenerator<StepResponse, StoreUpdateFromResult<T>>
 
   deleteFrom(
@@ -278,6 +278,9 @@ yield* store.update(`start:${message.id}`, draft => {
 
 `update` is a durable step. The key is the workflow step key for that update.
 
+Updaters are synchronous, deterministic, and side-effect-free. A CAS conflict
+may run the updater again against a newer snapshot before it commits.
+
 If replayed, the workflow step cache returns the recorded `StoreUpdateResult` and the runtime does not call the store updater again. This holds even when the previous run crashed after the store commit but before the workflow heap write, because the store itself records the committed result in the applied-steps ledger (see below) inside the same transaction as the state change.
 
 Public `paths` are not accepted. The runtime derives changed paths from the update itself: the updater runs against a write-recording proxy over the draft, and every `set`/`deleteProperty` through the proxy records its full path (mutating array methods are captured naturally via the index/length writes they perform). This makes path derivation O(changes) rather than O(state size). If the updater returns a replacement state instead of mutating the draft, the runtime falls back to deep-diffing the previous and next states. Changed paths only affect wake precision, never state correctness, so ambiguous operations are recorded conservatively – an extra path is at worst a spurious wake, which replay absorbs.
@@ -289,6 +292,9 @@ Update semantics:
 - The updated state is validated against the store schema before commit.
 - The update result records `previousVersion` and `version`.
 - The runtime records changed paths internally for waiter wakeups.
+- A rejected update does not prove that its mutation rolled back: wake delivery
+  can fail after the state commit. Retrying is exactly-once only with the same
+  workflow `stepId`; external callers must read and reconcile before retrying.
 
 ## `when`
 
@@ -356,10 +362,10 @@ The key is REQUIRED – takes live in loops, and a call-site-hash default would 
 Semantics:
 
 - `take` is a durable step: on cache hit, replay returns the recorded selected value; the selector and claim never re-run.
-- On first execution, within the store's write transaction:
+- On first execution, using the store's CAS protocol:
   1. Run the selector against the current state via the read-tracking proxy.
-  2. If the selector returns a truthy value: apply `claim(draft, selected)`, validate the resulting state against the schema, commit as a single update (version + 1), compute changed paths and wake other waiters exactly like `update` does, persist the selected value as the step result, and return it.
-  3. If the selector returns a falsy value: commit nothing, register a waiter with the tracked read paths and the version observed inside the transaction (so the sinceVersion is exact by construction, closing the lost-wakeup gap), and suspend.
+  2. If the selector returns a truthy value: apply `claim(draft, selected)`, validate the resulting state against the schema, conditionally commit a single version bump, record the changed paths and selected step result, and return it. A CAS conflict restarts selection and claiming from the newer snapshot.
+  3. If the selector returns a falsy value: commit nothing, register a waiter with the tracked read paths and observed version, then recheck the store version before suspending. This closes the lost-wakeup gap without holding a transaction while the selector runs.
 - On wake, replay re-runs the whole take. A competing consumer may have already claimed the item – the selector then misses and the waiter re-registers. Spurious wakes are safe.
 - Return value (reference-snapshot rule): the selector runs against the draft, so a selected value that is a reference into state is snapshotted AFTER the claim runs – e.g. a claimed message is returned with `claimedBy` populated. A derived value (a `filter().length`, a mapped object) is returned as computed; the claim cannot appear in it. The selector cannot be re-run post-claim, because a correct claim makes the selector stop matching.
 - `claim` must be synchronous. The runtime rejects (throws) if it returns a Promise.
@@ -434,12 +440,12 @@ interface RuntimeStore<T> {
   get(): Promise<StoreSnapshot<T>>
 
   update(
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+    updater: (draft: Draft<T>) => void | T
   ): Promise<StoreUpdateResult<T>>
 
   updateFrom(
     snapshot: StoreSnapshot<T>,
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+    updater: (draft: Draft<T>) => void | T
   ): Promise<StoreUpdateFromResult<T>>
 
   deleteFrom(snapshot: StoreSnapshot<T>): Promise<StoreDeleteFromResult>

--- a/docs/manual/store-external.md
+++ b/docs/manual/store-external.md
@@ -30,7 +30,14 @@ zero.
 
 ## Writing
 
-`update` takes the same draft-mutating updater as the workflow API. The write commits in a single transaction, validated against the schema, and increments the version by one.
+`update` takes the same synchronous, pure draft-mutating updater as the workflow
+API. The runtime validates the resulting state and conditionally commits one
+version increment. A version conflict may re-run the updater against newer
+state.
+
+External updates do not carry a workflow `stepId`. If an update rejects after
+the state committed but wake delivery failed, blindly retrying can apply it
+twice. Read the store and reconcile before deciding whether to retry.
 
 ```ts
 await conversation.update((draft) => {

--- a/docs/manual/store-external.md
+++ b/docs/manual/store-external.md
@@ -31,13 +31,9 @@ zero.
 ## Writing
 
 `update` takes the same synchronous, pure draft-mutating updater as the workflow
-API. The runtime validates the resulting state and conditionally commits one
-version increment. A version conflict may re-run the updater against newer
-state.
-
-External updates do not carry a workflow `stepId`. If an update rejects after
-the state committed but wake delivery failed, blindly retrying can apply it
-twice. Read the store and reconcile before deciding whether to retry.
+API. The runtime validates the resulting state and increments the version by
+one. Concurrent updates are retried against the latest state, so the updater
+must be synchronous and side-effect-free.
 
 ```ts
 await conversation.update((draft) => {
@@ -93,4 +89,6 @@ const msg = yield* store.take(
 );
 ```
 
-External updates sit outside workflow step caching. There is no step key, so each call applies once, when it runs. If your handler retries, idempotency is yours to manage.
+External updates are not workflow steps and have no step key. If a request
+fails or your handler retries, read the current store and decide whether the
+write still needs to be applied.

--- a/docs/manual/stores.md
+++ b/docs/manual/stores.md
@@ -90,8 +90,8 @@ Updates are idempotent by step key. On replay, the runtime returns the cached re
 
 What if the process crashes after the store commits, but before the step result is recorded? The store covers this case itself. Every workflow update writes a row to an applied-steps ledger, in the same transaction as the state change. When the workflow replays, the store finds the ledger row and returns the recorded result, rather than running the updater a second time.
 
-Updaters must be synchronous, deterministic, and side-effect-free. The public
-signature no longer accepts promises. Do not perform network calls, timers, or
+Updaters must be synchronous, deterministic, and side-effect-free. Updater
+signatures do not accept promises. Do not perform network calls, timers, or
 other observable work: CAS conflicts may re-run the updater.
 
 An update rejection does not prove that its state change rolled back. A runtime

--- a/docs/manual/stores.md
+++ b/docs/manual/stores.md
@@ -81,18 +81,15 @@ yield* store.update(`finish:${msg.id}`, (draft) => {
 });
 ```
 
-The updater runs locally against a snapshot. The new state is validated against
-the schema, then committed with a conditional version check and a single
-version increment. If another writer wins, the updater may run again against
-the newer snapshot.
+The runtime validates the new state, commits it, and increments the version by
+one. Concurrent updates are retried against the latest state, so an updater may
+run more than once.
 
-Updates are idempotent by step key. On replay, the runtime returns the cached result and skips the updater.
+Updates are durable and idempotent by step key. On replay, the runtime returns
+the recorded result without running the updater again.
 
-What if the process crashes after the store commits, but before the step result is recorded? The store covers this case itself. Every workflow update writes a row to an applied-steps ledger, in the same transaction as the state change. When the workflow replays, the store finds the ledger row and returns the recorded result, rather than running the updater a second time.
-
-Updaters must be synchronous, deterministic, and side-effect-free. Updater
-signatures do not accept promises. Do not perform network calls, timers, or
-other observable work: CAS conflicts may re-run the updater.
+Updaters must be synchronous and side-effect-free. Do not perform network
+calls, start timers, or modify anything outside the draft.
 
 When a decision depends on an earlier read, use `updateFrom` to commit only if
 the store has not changed since that snapshot:
@@ -137,10 +134,8 @@ if (!result.deleted) {
 ```
 
 The store is deleted only when its instance ID and version still match the
-snapshot. Successful workflow deletions are written to the applied-steps
-ledger before commit, and that ledger entry survives deletion. Replay therefore
-returns the committed result without deleting a newer store created under the
-same logical ID.
+snapshot. Replaying a successful deletion returns its recorded result without
+deleting a newer store created under the same logical ID.
 
 Runtime integrations can call `listStores(definition)` to get the definition's
 live logical IDs in ascending order, and `deleteStore({ definition, id })` for

--- a/docs/manual/stores.md
+++ b/docs/manual/stores.md
@@ -81,13 +81,23 @@ yield* store.update(`finish:${msg.id}`, (draft) => {
 });
 ```
 
-Each update runs in a single store transaction. The new state is validated against the schema before it commits, and the version increments by one.
+The updater runs locally against a snapshot. The new state is validated against
+the schema, then committed with a conditional version check and a single
+version increment. If another writer wins, the updater may run again against
+the newer snapshot.
 
 Updates are idempotent by step key. On replay, the runtime returns the cached result and skips the updater.
 
 What if the process crashes after the store commits, but before the step result is recorded? The store covers this case itself. Every workflow update writes a row to an applied-steps ledger, in the same transaction as the state change. When the workflow replays, the store finds the ledger row and returns the recorded result, rather than running the updater a second time.
 
-Keep updaters synchronous and pure. The signature allows async, but an updater holds the store's write transaction open while it runs – no network calls, no timers.
+Updaters must be synchronous, deterministic, and side-effect-free. The public
+signature no longer accepts promises. Do not perform network calls, timers, or
+other observable work: CAS conflicts may re-run the updater.
+
+An update rejection does not prove that its state change rolled back. A runtime
+can commit the mutation and then fail while delivering its durable wake intents.
+Workflow updates retry exactly once when they reuse the same step key; external
+callers have no `stepId` and must read and reconcile before retrying.
 
 When a decision depends on an earlier read, use `updateFrom` to commit only if
 the store has not changed since that snapshot:

--- a/docs/manual/stores.md
+++ b/docs/manual/stores.md
@@ -94,11 +94,6 @@ Updaters must be synchronous, deterministic, and side-effect-free. Updater
 signatures do not accept promises. Do not perform network calls, timers, or
 other observable work: CAS conflicts may re-run the updater.
 
-An update rejection does not prove that its state change rolled back. A runtime
-can commit the mutation and then fail while delivering its durable wake intents.
-Workflow updates retry exactly once when they reuse the same step key; external
-callers have no `stepId` and must read and reconcile before retrying.
-
 When a decision depends on an earlier read, use `updateFrom` to commit only if
 the store has not changed since that snapshot:
 

--- a/docs/packages/bun-sqlite-runtime.md
+++ b/docs/packages/bun-sqlite-runtime.md
@@ -47,7 +47,9 @@ const schedulerClient = new SqliteSchedulerClient({
 
 ## `SqliteStoreClient`
 
-`StoreClient` implementation backed by SQLite. Store state, waiting workflows, and the applied-steps ledger live in three tables (`stores`, `store_waiters`, `store_applied_steps`). Each update writes to all three inside a single transaction.
+`StoreClient` implementation backed by SQLite. Store state, waiting workflows,
+the applied-steps ledger, and durable wake intents live in `stores`,
+`store_waiters`, `store_applied_steps`, and `store_wake_outbox`.
 
 ```ts
 import { SqliteStoreClient } from "@yieldstar/bun-sqlite-runtime";
@@ -55,9 +57,18 @@ import { SqliteStoreClient } from "@yieldstar/bun-sqlite-runtime";
 const storeClient = new SqliteStoreClient({ db, schedulerClient });
 ```
 
-The constructor takes a scheduler as well as the database. When an update changes state that a suspended workflow is waiting on, the client hands that workflow's event to the scheduler, which queues it for re-execution.
+The constructor takes a scheduler as well as the database. When an update
+changes a path that a suspended workflow observed, the same conditional
+transaction that writes the state and applied-step receipt also records a wake
+intent. After commit, the client drains those intents into the scheduler. A
+failed delivery remains in the outbox and is retried by the next operation or
+by a newly constructed client.
 
-Updaters may be async, and an async updater could otherwise let a second update begin while the first transaction is still open. To prevent this, the client pushes every write through an internal queue and runs them one at a time.
+Updaters must be synchronous, deterministic, and side-effect-free. They run
+against a snapshot outside the SQLite transaction; if the conditional commit
+loses a version race, the shared CAS client runs the updater again against the
+newer snapshot. The internal write queue serializes only SQLite transactions
+and outbox delivery on that client.
 
 ## `SqliteEventLoop`
 

--- a/docs/packages/bun-sqlite-runtime.md
+++ b/docs/packages/bun-sqlite-runtime.md
@@ -62,7 +62,9 @@ changes a path that a suspended workflow observed, the same conditional
 transaction that writes the state and applied-step receipt also records a wake
 intent. After commit, the client drains those intents into the scheduler. A
 failed delivery remains in the outbox and is retried by the next operation or
-by a newly constructed client.
+by a newly constructed client. Delivery is best-effort and does not reject an
+otherwise committed store mutation; one failing intent also does not block
+later outbox rows.
 
 Updaters must be synchronous, deterministic, and side-effect-free. They run
 against a snapshot outside the SQLite transaction; if the conditional commit

--- a/docs/packages/bun-sqlite-runtime.md
+++ b/docs/packages/bun-sqlite-runtime.md
@@ -48,7 +48,7 @@ const schedulerClient = new SqliteSchedulerClient({
 ## `SqliteStoreClient`
 
 `StoreClient` implementation backed by SQLite. Store state, waiting workflows,
-the applied-steps ledger, and durable wake intents live in `stores`,
+recorded workflow-step results, and pending wake-ups live in `stores`,
 `store_waiters`, `store_applied_steps`, and `store_wake_outbox`.
 
 ```ts
@@ -60,17 +60,16 @@ const storeClient = new SqliteStoreClient({ db, schedulerClient });
 The constructor takes a scheduler as well as the database. When an update
 changes a path that a suspended workflow observed, the same conditional
 transaction that writes the state and applied-step receipt also records a wake
-intent. After commit, the client drains those intents into the scheduler. A
-failed delivery remains in the outbox and is retried after the next committed
-mutation or by a newly constructed client. Delivery is best-effort and does
-not reject an otherwise committed store mutation; one failing intent also does
-not block later outbox rows.
+intent in the outbox. After commit, the client sends pending wake-ups to the
+scheduler. Failed deliveries remain pending and are retried after another
+committed mutation or when a client starts. A scheduler failure does not fail
+an otherwise committed store update or block other pending wake-ups.
 
 Updaters must be synchronous, deterministic, and side-effect-free. They run
 against a snapshot outside the SQLite transaction; if the conditional commit
-loses a version race, the shared CAS client runs the updater again against the
-newer snapshot. The internal write queue serializes only SQLite transactions
-and outbox delivery on that client.
+loses a version race, the base store client runs the updater again against the
+latest snapshot. The internal write queue serializes SQLite transactions and
+outbox delivery for each client.
 
 ## `SqliteEventLoop`
 

--- a/docs/packages/bun-sqlite-runtime.md
+++ b/docs/packages/bun-sqlite-runtime.md
@@ -61,10 +61,10 @@ The constructor takes a scheduler as well as the database. When an update
 changes a path that a suspended workflow observed, the same conditional
 transaction that writes the state and applied-step receipt also records a wake
 intent. After commit, the client drains those intents into the scheduler. A
-failed delivery remains in the outbox and is retried by the next operation or
-by a newly constructed client. Delivery is best-effort and does not reject an
-otherwise committed store mutation; one failing intent also does not block
-later outbox rows.
+failed delivery remains in the outbox and is retried after the next committed
+mutation or by a newly constructed client. Delivery is best-effort and does
+not reject an otherwise committed store mutation; one failing intent also does
+not block later outbox rows.
 
 Updaters must be synchronous, deterministic, and side-effect-free. They run
 against a snapshot outside the SQLite transaction; if the conditional commit

--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -70,7 +70,11 @@ interface SchedulerClient {
 
 ## `StoreClient` (abstract class)
 
-Persistence layer for [durable stores](../manual/stores.md). An implementation owns three things: store state and versions, the waiters created when `when`/`take` suspends a workflow, and an applied-steps ledger. The ledger records the result of each committed workflow update, keyed by `(executionId, stepKey)`, so that a replayed step can return the recorded result instead of running its updater again.
+Persistence layer for [durable stores](../manual/stores.md). An implementation
+owns store state and versions, waiters created by `when`/`take`, an applied-steps
+ledger, and durable wake delivery. The ledger records each committed workflow
+update by `(executionId, stepKey)`, while connector-specific wake intents ensure
+a committed change is eventually delivered after an interruption.
 
 ```ts
 abstract getOrCreateStore(params: {
@@ -117,7 +121,9 @@ An implementation must uphold four contracts:
 - Snapshot-based updates and deletions compare both the instance ID and version.
 - When `stepId` is provided and the ledger already holds that step, the implementation returns the recorded result and does not run the updater.
 - `registerWaiter` compares the store's current instance and version with the waiter; if either has moved on, it wakes the waiter immediately rather than leaving it to sleep through a write that already happened.
-- A waiter is removed only after its wake-up is queued. A crash in between produces a duplicate wake, which replay absorbs – the reverse order would lose the wake entirely.
+- A waiter is removed only after its durable wake is queued. SQLite records the
+  wake intent atomically with the mutation and drains it through an outbox; a
+  crash can produce a duplicate wake, which replay safely absorbs.
 
 ## `WorkflowInvoker` (type)
 

--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -72,9 +72,9 @@ interface SchedulerClient {
 
 Persistence layer for [durable stores](../manual/stores.md). An implementation
 owns store state and versions, waiters created by `when`/`take`, an applied-steps
-ledger, and durable wake delivery. The ledger records each committed workflow
-update by `(executionId, stepKey)`, while connector-specific wake intents ensure
-a committed change is eventually delivered after an interruption.
+ledger, and wake delivery. The ledger records each committed workflow update by
+`(executionId, stepKey)` so replay can return the result without applying the
+update again.
 
 ```ts
 abstract getOrCreateStore(params: {
@@ -114,16 +114,41 @@ abstract registerWaiter(waiter: StoreWaiter): Promise<void>;
 
 The base class also provides `storeClient.store(definition, id)`, the external read/write handle described in [External Store Access](../manual/store-external.md).
 
-An implementation must uphold four contracts:
+An implementation must uphold these contracts:
 
 - Every store instance has a UUIDv7 instance ID; `(definition.name, id)` remains the unique logical lookup key.
-- Each update commits in a single per-store transaction and increments the version by one.
+- Each update atomically writes the state, increments the version by one, and records its workflow-step result when a `stepId` is present.
 - Snapshot-based updates and deletions compare both the instance ID and version.
 - When `stepId` is provided and the ledger already holds that step, the implementation returns the recorded result and does not run the updater.
 - `registerWaiter` compares the store's current instance and version with the waiter; if either has moved on, it wakes the waiter immediately rather than leaving it to sleep through a write that already happened.
-- A waiter is removed only after its durable wake is queued. SQLite records the
-  wake intent atomically with the mutation and drains it through an outbox; a
-  crash can produce a duplicate wake, which replay safely absorbs.
+- Matching waiters remain registered until their wake-up is queued. Scheduler
+  failures do not reject committed updates, and pending wake-ups are retried by
+  later writes. Durable connectors persist wake intents atomically with the
+  state change so process interruption cannot lose them.
+
+## `CasStoreClient` (abstract class)
+
+Base class for connectors that support compare-and-swap (CAS). It implements
+`updateStore`, `updateStoreFrom`, and `takeFromStore`; a connector supplies
+ledger lookup and the atomic mutation operation:
+
+```ts
+abstract getAppliedStoreStep(params): Promise<{ result: unknown } | undefined>;
+
+abstract commitStoreMutation(
+  mutation: StoreMutation
+): Promise<
+  | { status: "committed" }
+  | { status: "already-applied"; result: unknown }
+  | { status: "conflict"; snapshot: StoreSnapshot<unknown> }
+>;
+```
+
+`commitStoreMutation` checks the applied-step ledger first, compares the
+expected instance ID and version, and atomically writes the next state, version,
+step result, and any durable wake intents. On conflict it returns the current
+snapshot so the base class can recompute the update. Application callbacks run
+outside the connector's transaction and may run more than once.
 
 ## `WorkflowInvoker` (type)
 

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -57,6 +57,197 @@ test("sqlite store updates wake matching waiters", async () => {
   expect(events).toEqual([event]);
 });
 
+test("retry delivers a wake whose first enqueue failed after the store commit", async () => {
+  const db = new Database(":memory:");
+  const events: WorkflowEvent[] = [];
+  let wakeAttempts = 0;
+  const schedulerClient: SchedulerClient = {
+    async requestWakeUp(event) {
+      wakeAttempts += 1;
+      if (wakeAttempts === 1) throw new Error("wake enqueue failed");
+      events.push(event);
+    },
+  };
+  const client = new SqliteStoreClient({ db, schedulerClient });
+  const event = {
+    workflowId: "workflow",
+    executionId: "execution",
+    params: undefined,
+    context: new Map(),
+  };
+
+  const initial = await client.getOrCreateStore({
+    definition: Store,
+    id: "wake-enqueue-retry",
+    initial: { messages: [] },
+  });
+  await client.registerWaiter({
+    workflowId: event.workflowId,
+    executionId: event.executionId,
+    stepKey: "next-message",
+    event,
+    storeName: Store.name,
+    storeId: "wake-enqueue-retry",
+    instanceId: initial.instanceId,
+    sinceVersion: initial.version,
+    readPaths: [["messages"]],
+  });
+
+  const update = () =>
+    client.updateStore({
+      definition: Store,
+      id: "wake-enqueue-retry",
+      updater(draft) {
+        draft.messages.push({ id: "msg-1" });
+      },
+      stepId: { executionId: "updater", stepKey: "append-message" },
+    });
+
+  await expect(update()).rejects.toThrow("wake enqueue failed");
+  await update();
+
+  expect(wakeAttempts).toBe(2);
+  expect(events).toEqual([event]);
+  expect(
+    await client.getStore({
+      definition: Store,
+      id: "wake-enqueue-retry",
+    })
+  ).toMatchObject({
+    state: { messages: [{ id: "msg-1" }] },
+    version: 1,
+  });
+});
+
+test("a new sqlite store client recovers a committed wake after interruption", async () => {
+  const db = new Database(":memory:");
+  const interruptedClient = new SqliteStoreClient({
+    db,
+    schedulerClient: {
+      async requestWakeUp() {
+        throw new Error("process interrupted before wake enqueue");
+      },
+    },
+  });
+  const event = {
+    workflowId: "workflow",
+    executionId: "execution",
+    params: undefined,
+    context: new Map(),
+  };
+
+  const initial = await interruptedClient.getOrCreateStore({
+    definition: Store,
+    id: "wake-recovery",
+    initial: { messages: [] },
+  });
+  await interruptedClient.registerWaiter({
+    workflowId: event.workflowId,
+    executionId: event.executionId,
+    stepKey: "next-message",
+    event,
+    storeName: Store.name,
+    storeId: "wake-recovery",
+    instanceId: initial.instanceId,
+    sinceVersion: initial.version,
+    readPaths: [["messages"]],
+  });
+
+  await expect(
+    interruptedClient.updateStore({
+      definition: Store,
+      id: "wake-recovery",
+      updater(draft) {
+        draft.messages.push({ id: "msg-1" });
+      },
+      stepId: { executionId: "updater", stepKey: "append-message" },
+    })
+  ).rejects.toThrow("process interrupted before wake enqueue");
+
+  const recoveredEvents: WorkflowEvent[] = [];
+  new SqliteStoreClient({
+    db,
+    schedulerClient: {
+      async requestWakeUp(recoveredEvent) {
+        recoveredEvents.push(recoveredEvent);
+      },
+    },
+  });
+  await Bun.sleep(0);
+
+  expect(recoveredEvents).toEqual([event]);
+});
+
+test("wake delivery does not delete a waiter re-registered by another client", async () => {
+  const db = new Database(":memory:");
+  const event = {
+    workflowId: "workflow",
+    executionId: "execution",
+    params: undefined,
+    context: new Map(),
+  };
+  let secondClient: SqliteStoreClient;
+  let wakeCount = 0;
+  const firstClient = new SqliteStoreClient({
+    db,
+    schedulerClient: {
+      async requestWakeUp() {
+        wakeCount++;
+        if (wakeCount === 1) {
+          const current = await secondClient.getStore({
+            definition: Store,
+            id: "re-register",
+          });
+          await secondClient.registerWaiter({
+            workflowId: event.workflowId,
+            executionId: event.executionId,
+            stepKey: "next-message",
+            event,
+            storeName: Store.name,
+            storeId: "re-register",
+            instanceId: current.instanceId,
+            sinceVersion: current.version,
+            readPaths: [["messages"]],
+          });
+        }
+      },
+    },
+  });
+  secondClient = new SqliteStoreClient({
+    db,
+    schedulerClient: { async requestWakeUp() {} },
+  });
+
+  const initial = await firstClient.getOrCreateStore({
+    definition: Store,
+    id: "re-register",
+    initial: { messages: [] },
+  });
+  await firstClient.registerWaiter({
+    workflowId: event.workflowId,
+    executionId: event.executionId,
+    stepKey: "next-message",
+    event,
+    storeName: Store.name,
+    storeId: "re-register",
+    instanceId: initial.instanceId,
+    sinceVersion: initial.version,
+    readPaths: [["messages"]],
+  });
+
+  for (const id of ["msg-1", "msg-2"]) {
+    await firstClient.updateStore({
+      definition: Store,
+      id: "re-register",
+      updater(draft) {
+        draft.messages.push({ id });
+      },
+    });
+  }
+
+  expect(wakeCount).toBe(2);
+});
+
 test("registering a waiter with a stale sinceVersion triggers an immediate wake", async () => {
   const db = new Database(":memory:");
   const events: WorkflowEvent[] = [];
@@ -114,7 +305,7 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
   expect(events).toEqual([]);
 });
 
-test("concurrent async updaters on one client both commit", async () => {
+test("concurrent synchronous updates on one client both commit", async () => {
   const db = new Database(":memory:");
   const schedulerClient: SchedulerClient = {
     async requestWakeUp() {},
@@ -131,16 +322,14 @@ test("concurrent async updaters on one client both commit", async () => {
     client.updateStore({
       definition: Store,
       id: "race",
-      async updater(draft) {
-        await Promise.resolve();
+      updater(draft) {
         draft.messages.push({ id: "msg-a" });
       },
     }),
     client.updateStore({
       definition: Store,
       id: "race",
-      async updater(draft) {
-        await Promise.resolve();
+      updater(draft) {
         draft.messages.push({ id: "msg-b" });
       },
     }),
@@ -151,6 +340,33 @@ test("concurrent async updaters on one client both commit", async () => {
   const snapshot = await client.getStore({ definition: Store, id: "race" });
   expect(snapshot.version).toBe(2);
   expect(snapshot.state.messages).toEqual([{ id: "msg-a" }, { id: "msg-b" }]);
+});
+
+test("async updaters are rejected without committing", async () => {
+  const db = new Database(":memory:");
+  const client = new SqliteStoreClient({
+    db,
+    schedulerClient: { async requestWakeUp() {} },
+  });
+  await client.getOrCreateStore({
+    definition: Store,
+    id: "async-updater",
+    initial: { messages: [] },
+  });
+
+  await expect(
+    client.updateStore({
+      definition: Store,
+      id: "async-updater",
+      updater: (async (draft: State) => {
+        draft.messages.push({ id: "never-committed" });
+      }) as any,
+    })
+  ).rejects.toThrow("Store updaters must be synchronous");
+
+  expect(
+    await client.getStore({ definition: Store, id: "async-updater" })
+  ).toMatchObject({ state: { messages: [] }, version: 0 });
 });
 
 test("updateStoreFrom commits only from the supplied snapshot and replays ledger-first", async () => {
@@ -219,6 +435,41 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
     actualVersion: 2,
   });
   expect(updaterRuns).toBe(1);
+});
+
+test("updateStoreFrom normalizes legacy applied-step receipts", async () => {
+  const db = new Database(":memory:");
+  const client = new SqliteStoreClient({
+    db,
+    schedulerClient: { async requestWakeUp() {} },
+  });
+  const snapshot = await client.getOrCreateStore({
+    definition: Store,
+    id: "legacy-receipt",
+    initial: { messages: [] },
+  });
+  const result = {
+    state: { messages: [{ id: "msg-1" }] },
+    previousVersion: 0,
+    version: 1,
+  };
+  db.query(
+    `INSERT INTO store_applied_steps
+       (store_name, store_id, execution_id, step_key, result)
+     VALUES (?, ?, ?, ?, ?)`
+  ).run(Store.name, "legacy-receipt", "execution", "update", JSON.stringify(result));
+
+  expect(
+    await client.updateStoreFrom({
+      definition: Store,
+      id: "legacy-receipt",
+      snapshot,
+      stepId: { executionId: "execution", stepKey: "update" },
+      updater() {
+        throw new Error("legacy receipt should win before updater execution");
+      },
+    })
+  ).toEqual({ updated: true, ...result });
 });
 
 test("listStores and deleteStore manage logical store instances", async () => {

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -57,7 +57,7 @@ test("sqlite store updates wake matching waiters", async () => {
   expect(events).toEqual([event]);
 });
 
-test("retry delivers a wake whose first enqueue failed after the store commit", async () => {
+test("wake failure does not reject a committed update and ledger replay retries it", async () => {
   const db = new Database(":memory:");
   const events: WorkflowEvent[] = [];
   let wakeAttempts = 0;
@@ -103,7 +103,8 @@ test("retry delivers a wake whose first enqueue failed after the store commit", 
       stepId: { executionId: "updater", stepKey: "append-message" },
     });
 
-  await expect(update()).rejects.toThrow("wake enqueue failed");
+  await update();
+  expect(wakeAttempts).toBe(1);
   await update();
 
   expect(wakeAttempts).toBe(2);
@@ -153,16 +154,14 @@ test("a new sqlite store client recovers a committed wake after interruption", a
     readPaths: [["messages"]],
   });
 
-  await expect(
-    interruptedClient.updateStore({
-      definition: Store,
-      id: "wake-recovery",
-      updater(draft) {
-        draft.messages.push({ id: "msg-1" });
-      },
-      stepId: { executionId: "updater", stepKey: "append-message" },
-    })
-  ).rejects.toThrow("process interrupted before wake enqueue");
+  await interruptedClient.updateStore({
+    definition: Store,
+    id: "wake-recovery",
+    updater(draft) {
+      draft.messages.push({ id: "msg-1" });
+    },
+    stepId: { executionId: "updater", stepKey: "append-message" },
+  });
 
   const recoveredEvents: WorkflowEvent[] = [];
   new SqliteStoreClient({
@@ -176,6 +175,78 @@ test("a new sqlite store client recovers a committed wake after interruption", a
   await Bun.sleep(0);
 
   expect(recoveredEvents).toEqual([event]);
+});
+
+test("a poisoned wake neither blocks later rows nor unrelated store commits", async () => {
+  const db = new Database(":memory:");
+  const delivered: WorkflowEvent[] = [];
+  const client = new SqliteStoreClient({
+    db,
+    schedulerClient: {
+      async requestWakeUp(event) {
+        if (event.executionId === "a-poison") {
+          throw new Error("poisoned wake");
+        }
+        delivered.push(event);
+      },
+    },
+  });
+  const initial = await client.getOrCreateStore({
+    definition: Store,
+    id: "poisoned-outbox",
+    initial: { messages: [] },
+  });
+
+  for (const executionId of ["a-poison", "b-good"]) {
+    const event = {
+      workflowId: "workflow",
+      executionId,
+      params: undefined,
+      context: new Map(),
+    };
+    await client.registerWaiter({
+      workflowId: event.workflowId,
+      executionId,
+      stepKey: "next-message",
+      event,
+      storeName: Store.name,
+      storeId: "poisoned-outbox",
+      instanceId: initial.instanceId,
+      sinceVersion: initial.version,
+      readPaths: [["messages"]],
+    });
+  }
+
+  await client.updateStore({
+    definition: Store,
+    id: "poisoned-outbox",
+    updater(draft) {
+      draft.messages.push({ id: "msg-1" });
+    },
+  });
+
+  expect(delivered.map((event) => event.executionId)).toEqual(["b-good"]);
+  expect(
+    db.query(
+      `SELECT execution_id FROM store_wake_outbox ORDER BY execution_id`
+    ).all()
+  ).toEqual([{ execution_id: "a-poison" }]);
+
+  await client.getOrCreateStore({
+    definition: Store,
+    id: "unrelated",
+    initial: { messages: [] },
+  });
+  await client.updateStore({
+    definition: Store,
+    id: "unrelated",
+    updater(draft) {
+      draft.messages.push({ id: "unrelated-msg" });
+    },
+  });
+  expect(
+    await client.getStore({ definition: Store, id: "unrelated" })
+  ).toMatchObject({ version: 1 });
 });
 
 test("wake delivery does not delete a waiter re-registered by another client", async () => {

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -57,7 +57,7 @@ test("sqlite store updates wake matching waiters", async () => {
   expect(events).toEqual([event]);
 });
 
-test("wake failure does not reject a committed update and ledger replay retries it", async () => {
+test("wake failure does not reject or reapply a committed update on ledger replay", async () => {
   const db = new Database(":memory:");
   const events: WorkflowEvent[] = [];
   let wakeAttempts = 0;
@@ -107,8 +107,8 @@ test("wake failure does not reject a committed update and ledger replay retries 
   expect(wakeAttempts).toBe(1);
   await update();
 
-  expect(wakeAttempts).toBe(2);
-  expect(events).toEqual([event]);
+  expect(wakeAttempts).toBe(1);
+  expect(events).toEqual([]);
   expect(
     await client.getStore({
       definition: Store,

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -434,6 +434,17 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
     expectedVersion: 0,
     actualVersion: 2,
   });
+
+  await expect(
+    client.updateStoreFrom({
+      definition: Store,
+      id: "conditional",
+      snapshot: { ...snapshot, instanceId: "" },
+      updater() {
+        updaterRuns++;
+      },
+    })
+  ).rejects.toThrow("Store snapshot is missing instanceId");
   expect(updaterRuns).toBe(1);
 });
 

--- a/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.test.ts
@@ -519,41 +519,6 @@ test("updateStoreFrom commits only from the supplied snapshot and replays ledger
   expect(updaterRuns).toBe(1);
 });
 
-test("updateStoreFrom normalizes legacy applied-step receipts", async () => {
-  const db = new Database(":memory:");
-  const client = new SqliteStoreClient({
-    db,
-    schedulerClient: { async requestWakeUp() {} },
-  });
-  const snapshot = await client.getOrCreateStore({
-    definition: Store,
-    id: "legacy-receipt",
-    initial: { messages: [] },
-  });
-  const result = {
-    state: { messages: [{ id: "msg-1" }] },
-    previousVersion: 0,
-    version: 1,
-  };
-  db.query(
-    `INSERT INTO store_applied_steps
-       (store_name, store_id, execution_id, step_key, result)
-     VALUES (?, ?, ?, ?, ?)`
-  ).run(Store.name, "legacy-receipt", "execution", "update", JSON.stringify(result));
-
-  expect(
-    await client.updateStoreFrom({
-      definition: Store,
-      id: "legacy-receipt",
-      snapshot,
-      stepId: { executionId: "execution", stepKey: "update" },
-      updater() {
-        throw new Error("legacy receipt should win before updater execution");
-      },
-    })
-  ).toEqual({ updated: true, ...result });
-});
-
 test("listStores and deleteStore manage logical store instances", async () => {
   const db = new Database(":memory:");
   const client = new SqliteStoreClient({

--- a/packages/bun-sqlite-runtime/src/sqlite-store.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.ts
@@ -1,29 +1,20 @@
 import type { Database } from "bun:sqlite";
 import type { SchedulerClient, WorkflowEvent } from "@yieldstar/core";
 import {
-  assertSynchronousClaim,
   cloneStoreState,
-  diffStorePaths,
-  isStoreSelectorMatch,
-  StoreClient,
+  CasStoreClient,
   storePathsIntersect,
-  trackStoreSelector,
-  trackStoreUpdater,
-  unwrapTrackedValue,
   validateStoreState,
-  type Draft,
   type StandardSchemaV1,
   type StoreDefinition,
   type StoreDeleteFromResult,
   type StorePath,
-  type StoreSelector,
   type StoreSnapshot,
   type StoreState,
   type StoreStepId,
-  type StoreTakeResult,
-  type StoreUpdateFromResult,
-  type StoreUpdateResult,
   type StoreWaiter,
+  type StoreMutation,
+  type StoreMutationCommitResult,
 } from "@yieldstar/core";
 
 class StoreRow {
@@ -51,12 +42,19 @@ class WaiterRow {
   read_paths!: string;
 }
 
-export class SqliteStoreClient extends StoreClient {
+class WakeOutboxRow {
+  store_name!: string;
+  store_id!: string;
+  execution_id!: string;
+  step_key!: string;
+  event!: string | null;
+  since_version!: number | null;
+}
+
+export class SqliteStoreClient extends CasStoreClient {
   private db: Database;
   private schedulerClient: SchedulerClient;
-  // Serializes all write operations on this client. bun:sqlite uses a single
-  // connection, so awaiting an async updater between BEGIN IMMEDIATE and COMMIT
-  // would let a second concurrent write issue a nested BEGIN and throw.
+  // Serializes write transactions on this single bun:sqlite connection.
   private writeLock: Promise<unknown> = Promise.resolve();
 
   constructor(params: { db: Database; schedulerClient: SchedulerClient }) {
@@ -64,6 +62,12 @@ export class SqliteStoreClient extends StoreClient {
     this.db = params.db;
     this.schedulerClient = params.schedulerClient;
     this.setupDb();
+    // A previous process may have committed a store mutation and its wake
+    // intents before it could enqueue them. Delivery is idempotent, so every
+    // client startup can safely resume the durable outbox.
+    void this.enqueueWrite(() => this.drainWakeOutbox()).catch((error) => {
+      console.error("Failed to recover pending store wakes", error);
+    });
   }
 
   private enqueueWrite<R>(fn: () => Promise<R>): Promise<R> {
@@ -165,357 +169,115 @@ export class SqliteStoreClient extends StoreClient {
     };
   }
 
-  async updateStore<Schema extends StandardSchemaV1>(params: {
-    definition: StoreDefinition<Schema>;
+  protected async getAppliedStoreStep(params: {
+    definition: StoreDefinition;
     id: string;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
-    stepId?: StoreStepId;
-  }): Promise<StoreUpdateResult<StoreState<Schema>>> {
-    return (await this.updateStoreInternal(params)) as StoreUpdateResult<
-      StoreState<Schema>
-    >;
-  }
-
-  async updateStoreFrom<Schema extends StandardSchemaV1>(params: {
-    definition: StoreDefinition<Schema>;
-    id: string;
-    snapshot: StoreSnapshot<StoreState<Schema>>;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
-    stepId?: StoreStepId;
-  }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
-    const result = await this.updateStoreInternal({
-      ...params,
-      expectedInstanceId: params.snapshot.instanceId,
-      expectedVersion: params.snapshot.version,
-    });
-    return "updated" in result ? result : { updated: true, ...result };
-  }
-
-  private updateStoreInternal<Schema extends StandardSchemaV1>(params: {
-    definition: StoreDefinition<Schema>;
-    id: string;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
-    stepId?: StoreStepId;
-    expectedInstanceId?: string;
-    expectedVersion?: number;
-  }): Promise<
-    | StoreUpdateResult<StoreState<Schema>>
-    | Extract<StoreUpdateFromResult<StoreState<Schema>>, { updated: false }>
-  > {
+    stepId: StoreStepId;
+  }): Promise<{ result: unknown } | undefined> {
     return this.enqueueWrite(async () => {
-      let result: StoreUpdateResult<StoreState<Schema>>;
-      let waitersToWake: MatchedWaiter[] = [];
+      await this.drainWakeOutbox();
+      const row = this.getAppliedStepRow({
+        storeName: params.definition.name,
+        storeId: params.id,
+        stepId: params.stepId,
+      });
+      return row ? { result: JSON.parse(row.result) } : undefined;
+    });
+  }
 
+  protected commitStoreMutation(
+    mutation: StoreMutation
+  ): Promise<StoreMutationCommitResult> {
+    return this.enqueueWrite(async () => {
+      await this.drainWakeOutbox();
       this.db.run("BEGIN IMMEDIATE");
-
       try {
-        // Exactly-once: if this workflow step already committed, return the
-        // recorded result without re-running the updater.
-        if (params.stepId) {
+        if (mutation.stepId) {
           const applied = this.getAppliedStepRow({
-            storeName: params.definition.name,
-            storeId: params.id,
-            stepId: params.stepId,
+            storeName: mutation.definition.name,
+            storeId: mutation.id,
+            stepId: mutation.stepId,
           });
           if (applied) {
             this.db.run("COMMIT");
-            return JSON.parse(applied.result) as StoreUpdateResult<
-              StoreState<Schema>
-            >;
+            return {
+              status: "already-applied",
+              result: JSON.parse(applied.result),
+            };
           }
         }
 
-        if (params.expectedVersion !== undefined) {
-          this.assertSnapshotHasInstanceId({
-            instanceId: params.expectedInstanceId,
-          });
-        }
-
-        const row = this.getStoreRow(params.definition.name, params.id);
+        const row = this.getStoreRow(mutation.definition.name, mutation.id);
         if (!row) {
           throw new Error(
-            `Store "${params.definition.name}:${params.id}" does not exist`
+            `Store "${mutation.definition.name}:${mutation.id}" does not exist`
           );
         }
-
         if (
-          params.expectedInstanceId !== undefined &&
-          params.expectedVersion !== undefined &&
-          (row.instance_id !== params.expectedInstanceId ||
-            row.version !== params.expectedVersion)
+          row.instance_id !== mutation.expected.instanceId ||
+          row.version !== mutation.expected.version
         ) {
           this.db.run("COMMIT");
           return {
-            updated: false as const,
-            expectedInstanceId: params.expectedInstanceId,
-            actualInstanceId: row.instance_id,
-            expectedVersion: params.expectedVersion,
-            actualVersion: row.version,
+            status: "conflict",
+            snapshot: {
+              state: JSON.parse(row.state),
+              instanceId: row.instance_id,
+              version: row.version,
+            },
           };
         }
 
-        const previousState = JSON.parse(row.state) as StoreState<Schema>;
-        const draft = cloneStoreState(previousState) as Draft<
-          StoreState<Schema>
-        >;
-        // The updater runs against a write-recording proxy so changed paths
-        // are derived from its mutations in O(changes) – the full-state deep
-        // diff is only needed when the updater returns a replacement state
-        // (or validation returns a transformed copy).
-        const tracked = trackStoreUpdater(draft);
-        const updated = await params.updater(tracked.draft);
-        const returned =
-          updated === undefined ? undefined : unwrapTrackedValue(updated);
-        const isReplacement = returned !== undefined && returned !== draft;
-        const nextState = await validateStoreState(
-          params.definition,
-          isReplacement ? returned : draft
-        );
-        const changedPaths =
-          !isReplacement && (nextState as unknown) === draft
-            ? tracked.writePaths()
-            : diffStorePaths(previousState, nextState);
-        const committed = this.commitNextState({
-          storeName: params.definition.name,
-          storeId: params.id,
-          instanceId: row.instance_id,
-          changedPaths,
-          nextState,
-          previousVersion: row.version,
-        });
-        waitersToWake = committed.waitersToWake;
+        const version = mutation.expected.version + 1;
+        const changed = this.db
+          .query(
+            `UPDATE stores
+             SET version = $version, state = $state
+             WHERE instance_id = $instanceId AND version = $expectedVersion`
+          )
+          .run({
+            $instanceId: mutation.expected.instanceId,
+            $expectedVersion: mutation.expected.version,
+            $version: version,
+            $state: JSON.stringify(mutation.nextState),
+          });
+        if (changed.changes !== 1) {
+          throw new Error("Store changed during its mutation transaction");
+        }
 
-        result = {
-          state: cloneStoreState(nextState),
-          previousVersion: row.version,
-          version: committed.version,
-        };
-
-        // Ledger row commits atomically with the state update
-        if (params.stepId) {
+        if (mutation.stepId) {
           this.insertAppliedStepRow({
-            storeName: params.definition.name,
-            storeId: params.id,
-            stepId: params.stepId,
-            result: JSON.stringify({
-              state: nextState,
-              previousVersion: row.version,
-              version: committed.version,
-            }),
+            storeName: mutation.definition.name,
+            storeId: mutation.id,
+            stepId: mutation.stepId,
+            result: JSON.stringify(mutation.result),
+          });
+        }
+
+        const waiters = this.selectMatchingWaiters({
+          storeName: mutation.definition.name,
+          storeId: mutation.id,
+          version,
+          changedPaths: mutation.changedPaths,
+        });
+        for (const waiter of waiters) {
+          this.insertWakeOutboxRow({
+            storeName: mutation.definition.name,
+            storeId: mutation.id,
+            executionId: waiter.executionId,
+            stepKey: waiter.stepKey,
           });
         }
 
         this.db.run("COMMIT");
-      } catch (err) {
+      } catch (error) {
         this.db.run("ROLLBACK");
-        throw err;
+        throw error;
       }
 
-      await this.wakeWaiters({
-        storeName: params.definition.name,
-        storeId: params.id,
-        waiters: waitersToWake,
-      });
-
-      return result;
+      await this.drainWakeOutbox();
+      return { status: "committed" };
     });
-  }
-
-  async takeFromStore<Schema extends StandardSchemaV1, R>(params: {
-    definition: StoreDefinition<Schema>;
-    id: string;
-    selector: StoreSelector<StoreState<Schema>, R>;
-    claim: (
-      draft: Draft<StoreState<Schema>>,
-      selected: NonNullable<R>
-    ) => void;
-    stepId?: StoreStepId;
-  }): Promise<StoreTakeResult<R>> {
-    return this.enqueueWrite(async () => {
-      let result: StoreTakeResult<R>;
-      let waitersToWake: MatchedWaiter[] = [];
-
-      this.db.run("BEGIN IMMEDIATE");
-
-      try {
-        // Exactly-once: if this workflow step already committed a claim,
-        // return the recorded outcome without re-running selector/claim.
-        // Only matched takes are recorded – an unmatched take commits
-        // nothing and must be free to re-evaluate on the next wake.
-        if (params.stepId) {
-          const applied = this.getAppliedStepRow({
-            storeName: params.definition.name,
-            storeId: params.id,
-            stepId: params.stepId,
-          });
-          if (applied) {
-            this.db.run("COMMIT");
-            return JSON.parse(applied.result) as StoreTakeResult<R>;
-          }
-        }
-
-        const row = this.getStoreRow(params.definition.name, params.id);
-        if (!row) {
-          throw new Error(
-            `Store "${params.definition.name}:${params.id}" does not exist`
-          );
-        }
-
-        const previousState = JSON.parse(row.state) as StoreState<Schema>;
-        const draft = cloneStoreState(previousState) as Draft<
-          StoreState<Schema>
-        >;
-        // Wrap the draft in a write-recording proxy so the claim's mutations
-        // produce the changed paths (O(changes) instead of a full-state diff).
-        const tracked = trackStoreUpdater(draft);
-
-        // Run the selector against the mutable draft (through the
-        // read-tracking proxy over the recording proxy) so a selected value
-        // that is a reference into state observes the claim mutation before
-        // it is snapshotted – and so mutations through it are recorded.
-        const { result: selectedResult, readPaths } = trackStoreSelector(
-          tracked.draft as StoreState<Schema>,
-          params.selector
-        );
-
-        if (!isStoreSelectorMatch(selectedResult)) {
-          this.db.run("COMMIT");
-          return {
-            matched: false,
-            instanceId: row.instance_id,
-            version: row.version,
-            readPaths,
-          };
-        }
-
-        // Unwraps the selector proxy to the RECORDING proxy, so mutations
-        // via the selected reference are captured as write paths.
-        const selected = unwrapTrackedValue(
-          selectedResult
-        ) as NonNullable<R>;
-
-        assertSynchronousClaim(
-          params.claim(tracked.draft as Draft<StoreState<Schema>>, selected)
-        );
-
-        const nextState = await validateStoreState(params.definition, draft);
-        // Snapshot AFTER the claim ran (and unwrap any tracking proxies) so
-        // a selected reference into state reflects the claim mutation.
-        const selectedSnapshot = cloneStoreState(selected);
-        const changedPaths =
-          (nextState as unknown) === draft
-            ? tracked.writePaths()
-            : diffStorePaths(previousState, nextState);
-
-        const committed = this.commitNextState({
-          storeName: params.definition.name,
-          storeId: params.id,
-          instanceId: row.instance_id,
-          changedPaths,
-          nextState,
-          previousVersion: row.version,
-        });
-        waitersToWake = committed.waitersToWake;
-
-        result = {
-          matched: true,
-          selected: selectedSnapshot,
-          instanceId: row.instance_id,
-          version: committed.version,
-        };
-
-        // Ledger row commits atomically with the claim
-        if (params.stepId) {
-          this.insertAppliedStepRow({
-            storeName: params.definition.name,
-            storeId: params.id,
-            stepId: params.stepId,
-            result: JSON.stringify(result),
-          });
-        }
-
-        this.db.run("COMMIT");
-      } catch (err) {
-        this.db.run("ROLLBACK");
-        throw err;
-      }
-
-      await this.wakeWaiters({
-        storeName: params.definition.name,
-        storeId: params.id,
-        waiters: waitersToWake,
-      });
-
-      return result;
-    });
-  }
-
-  /**
-   * Writes the next state (version + 1) and collects the waiters woken by
-   * the changed paths. Must be called inside an open transaction.
-   */
-  private commitNextState(params: {
-    storeName: string;
-    storeId: string;
-    instanceId: string;
-    changedPaths: StorePath[];
-    nextState: unknown;
-    previousVersion: number;
-  }): { version: number; waitersToWake: MatchedWaiter[] } {
-    const { changedPaths } = params;
-    const version = params.previousVersion + 1;
-
-    this.db
-      .query(
-        `UPDATE stores
-         SET version = $version, state = $state
-         WHERE instance_id = $instanceId`
-      )
-      .run({
-        $storeName: params.storeName,
-        $storeId: params.storeId,
-        $instanceId: params.instanceId,
-        $version: version,
-        $state: JSON.stringify(params.nextState),
-      });
-
-    const waitersToWake = this.selectMatchingWaiters({
-      storeName: params.storeName,
-      storeId: params.storeId,
-      version,
-      changedPaths,
-    });
-
-    return { version, waitersToWake };
-  }
-
-  /**
-   * Wake durability: the waiter row is only deleted after the wake has
-   * been enqueued. If the process crashes between COMMIT and enqueue, the
-   * waiter survives and is woken by the next matching update. This may
-   * produce a duplicate wake, which is safe – replay re-evaluates the
-   * selector and re-registers if it still doesn't match.
-   */
-  private async wakeWaiters(params: {
-    storeName: string;
-    storeId: string;
-    waiters: MatchedWaiter[];
-  }) {
-    for (const waiter of params.waiters) {
-      await this.schedulerClient.requestWakeUp(waiter.event);
-      this.deleteWaiterRow({
-        storeName: params.storeName,
-        storeId: params.storeId,
-        executionId: waiter.executionId,
-        stepKey: waiter.stepKey,
-      });
-    }
   }
 
   async listStores<Schema extends StandardSchemaV1>(
@@ -551,6 +313,11 @@ export class SqliteStoreClient extends StoreClient {
         this.db
           .query(
             `DELETE FROM store_waiters WHERE store_name = $storeName AND store_id = $storeId`
+          )
+          .run(bindings);
+        this.db
+          .query(
+            `DELETE FROM store_wake_outbox WHERE store_name = $storeName AND store_id = $storeId`
           )
           .run(bindings);
         this.db.run("COMMIT");
@@ -619,6 +386,11 @@ export class SqliteStoreClient extends StoreClient {
           )
           .run(bindings);
         this.db
+          .query(
+            `DELETE FROM store_wake_outbox WHERE store_name = $storeName AND store_id = $storeId`
+          )
+          .run(bindings);
+        this.db
           .query(`DELETE FROM stores WHERE instance_id = $instanceId`)
           .run({ $instanceId: row.instance_id });
         const result = { deleted: true as const };
@@ -680,6 +452,12 @@ export class SqliteStoreClient extends StoreClient {
           row.version > waiter.sinceVersion
         ) {
           versionAdvanced = true;
+          this.insertWakeOutboxRow({
+            storeName: waiter.storeName,
+            storeId: waiter.storeId,
+            executionId: waiter.executionId,
+            stepKey: waiter.stepKey,
+          });
         }
 
         this.db.run("COMMIT");
@@ -689,13 +467,7 @@ export class SqliteStoreClient extends StoreClient {
       }
 
       if (versionAdvanced) {
-        await this.schedulerClient.requestWakeUp(waiter.event);
-        this.deleteWaiterRow({
-          storeName: waiter.storeName,
-          storeId: waiter.storeId,
-          executionId: waiter.executionId,
-          stepKey: waiter.stepKey,
-        });
+        await this.drainWakeOutbox();
       }
     });
   }
@@ -722,6 +494,14 @@ export class SqliteStoreClient extends StoreClient {
         execution_id TEXT NOT NULL,
         step_key TEXT NOT NULL,
         result TEXT NOT NULL,
+        PRIMARY KEY (store_name, store_id, execution_id, step_key)
+      );
+
+      CREATE TABLE IF NOT EXISTS store_wake_outbox (
+        store_name TEXT NOT NULL,
+        store_id TEXT NOT NULL,
+        execution_id TEXT NOT NULL,
+        step_key TEXT NOT NULL,
         PRIMARY KEY (store_name, store_id, execution_id, step_key)
       );
     `);
@@ -836,6 +616,7 @@ export class SqliteStoreClient extends StoreClient {
     storeId: string;
     executionId: string;
     stepKey: string;
+    sinceVersion?: number;
   }) {
     this.db
       .query(
@@ -843,7 +624,29 @@ export class SqliteStoreClient extends StoreClient {
          WHERE store_name = $storeName
            AND store_id = $storeId
            AND execution_id = $executionId
-           AND step_key = $stepKey`
+           AND step_key = $stepKey
+           AND ($sinceVersion IS NULL OR since_version = $sinceVersion)`
+      )
+      .run({
+        $storeName: params.storeName,
+        $storeId: params.storeId,
+        $executionId: params.executionId,
+        $stepKey: params.stepKey,
+        $sinceVersion: params.sinceVersion ?? null,
+      });
+  }
+
+  private insertWakeOutboxRow(params: {
+    storeName: string;
+    storeId: string;
+    executionId: string;
+    stepKey: string;
+  }) {
+    this.db
+      .query(
+        `INSERT OR IGNORE INTO store_wake_outbox
+           (store_name, store_id, execution_id, step_key)
+         VALUES ($storeName, $storeId, $executionId, $stepKey)`
       )
       .run({
         $storeName: params.storeName,
@@ -851,6 +654,58 @@ export class SqliteStoreClient extends StoreClient {
         $executionId: params.executionId,
         $stepKey: params.stepKey,
       });
+  }
+
+  private async drainWakeOutbox(): Promise<void> {
+    const rows = this.db
+      .query(
+        `SELECT
+           o.store_name,
+           o.store_id,
+           o.execution_id,
+           o.step_key,
+           w.event,
+           w.since_version
+         FROM store_wake_outbox o
+         LEFT JOIN store_waiters w
+           ON w.store_name = o.store_name
+          AND w.store_id = o.store_id
+          AND w.execution_id = o.execution_id
+          AND w.step_key = o.step_key
+         ORDER BY o.store_name, o.store_id, o.execution_id, o.step_key`
+      )
+      .as(WakeOutboxRow)
+      .all();
+
+    for (const row of rows) {
+      if (row.event !== null) {
+        await this.schedulerClient.requestWakeUp(
+          deserializeEvent(JSON.parse(row.event))
+        );
+        this.deleteWaiterRow({
+          storeName: row.store_name,
+          storeId: row.store_id,
+          executionId: row.execution_id,
+          stepKey: row.step_key,
+          sinceVersion: row.since_version ?? undefined,
+        });
+      }
+
+      this.db
+        .query(
+          `DELETE FROM store_wake_outbox
+           WHERE store_name = $storeName
+             AND store_id = $storeId
+             AND execution_id = $executionId
+             AND step_key = $stepKey`
+        )
+        .run({
+          $storeName: row.store_name,
+          $storeId: row.store_id,
+          $executionId: row.execution_id,
+          $stepKey: row.step_key,
+        });
+    }
   }
 
   private assertSnapshotHasInstanceId(snapshot: { instanceId?: string }) {

--- a/packages/bun-sqlite-runtime/src/sqlite-store.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.ts
@@ -172,15 +172,12 @@ export class SqliteStoreClient extends CasStoreClient {
     id: string;
     stepId: StoreStepId;
   }): Promise<{ result: unknown } | undefined> {
-    return this.enqueueWrite(async () => {
-      await this.drainWakeOutboxBestEffort();
-      const row = this.getAppliedStepRow({
-        storeName: params.definition.name,
-        storeId: params.id,
-        stepId: params.stepId,
-      });
-      return row ? { result: JSON.parse(row.result) } : undefined;
+    const row = this.getAppliedStepRow({
+      storeName: params.definition.name,
+      storeId: params.id,
+      stepId: params.stepId,
     });
+    return row ? { result: JSON.parse(row.result) } : undefined;
   }
 
   protected commitStoreMutation(

--- a/packages/bun-sqlite-runtime/src/sqlite-store.ts
+++ b/packages/bun-sqlite-runtime/src/sqlite-store.ts
@@ -65,9 +65,7 @@ export class SqliteStoreClient extends CasStoreClient {
     // A previous process may have committed a store mutation and its wake
     // intents before it could enqueue them. Delivery is idempotent, so every
     // client startup can safely resume the durable outbox.
-    void this.enqueueWrite(() => this.drainWakeOutbox()).catch((error) => {
-      console.error("Failed to recover pending store wakes", error);
-    });
+    void this.enqueueWrite(() => this.drainWakeOutboxBestEffort());
   }
 
   private enqueueWrite<R>(fn: () => Promise<R>): Promise<R> {
@@ -175,7 +173,7 @@ export class SqliteStoreClient extends CasStoreClient {
     stepId: StoreStepId;
   }): Promise<{ result: unknown } | undefined> {
     return this.enqueueWrite(async () => {
-      await this.drainWakeOutbox();
+      await this.drainWakeOutboxBestEffort();
       const row = this.getAppliedStepRow({
         storeName: params.definition.name,
         storeId: params.id,
@@ -189,7 +187,6 @@ export class SqliteStoreClient extends CasStoreClient {
     mutation: StoreMutation
   ): Promise<StoreMutationCommitResult> {
     return this.enqueueWrite(async () => {
-      await this.drainWakeOutbox();
       this.db.run("BEGIN IMMEDIATE");
       try {
         if (mutation.stepId) {
@@ -275,7 +272,10 @@ export class SqliteStoreClient extends CasStoreClient {
         throw error;
       }
 
-      await this.drainWakeOutbox();
+      // Wake delivery is deliberately outside the mutation result. Once the
+      // outbox intent commits, scheduler failure must not poison later store
+      // operations; another operation or client startup will retry it.
+      await this.drainWakeOutboxBestEffort();
       return { status: "committed" };
     });
   }
@@ -467,7 +467,7 @@ export class SqliteStoreClient extends CasStoreClient {
       }
 
       if (versionAdvanced) {
-        await this.drainWakeOutbox();
+        await this.drainWakeOutboxBestEffort();
       }
     });
   }
@@ -678,33 +678,48 @@ export class SqliteStoreClient extends CasStoreClient {
       .all();
 
     for (const row of rows) {
-      if (row.event !== null) {
-        await this.schedulerClient.requestWakeUp(
-          deserializeEvent(JSON.parse(row.event))
-        );
-        this.deleteWaiterRow({
-          storeName: row.store_name,
-          storeId: row.store_id,
-          executionId: row.execution_id,
-          stepKey: row.step_key,
-          sinceVersion: row.since_version ?? undefined,
-        });
-      }
+      try {
+        if (row.event !== null) {
+          await this.schedulerClient.requestWakeUp(
+            deserializeEvent(JSON.parse(row.event))
+          );
+          this.deleteWaiterRow({
+            storeName: row.store_name,
+            storeId: row.store_id,
+            executionId: row.execution_id,
+            stepKey: row.step_key,
+            sinceVersion: row.since_version ?? undefined,
+          });
+        }
 
-      this.db
-        .query(
-          `DELETE FROM store_wake_outbox
-           WHERE store_name = $storeName
-             AND store_id = $storeId
-             AND execution_id = $executionId
-             AND step_key = $stepKey`
-        )
-        .run({
-          $storeName: row.store_name,
-          $storeId: row.store_id,
-          $executionId: row.execution_id,
-          $stepKey: row.step_key,
-        });
+        this.db
+          .query(
+            `DELETE FROM store_wake_outbox
+             WHERE store_name = $storeName
+               AND store_id = $storeId
+               AND execution_id = $executionId
+               AND step_key = $stepKey`
+          )
+          .run({
+            $storeName: row.store_name,
+            $storeId: row.store_id,
+            $executionId: row.execution_id,
+            $stepKey: row.step_key,
+          });
+      } catch (error) {
+        // Leave only this row pending. A malformed event or event-specific
+        // scheduler failure must not prevent later wake intents from draining.
+        console.error("Failed to deliver pending store wake", error);
+      }
+    }
+  }
+
+  private async drainWakeOutboxBestEffort(): Promise<void> {
+    try {
+      await this.drainWakeOutbox();
+    } catch (error) {
+      // Query/database failures also stay outside store-operation success.
+      console.error("Failed to drain pending store wakes", error);
     }
   }
 

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -219,6 +219,10 @@ export abstract class StoreClient {
    * Updates a store's state atomically.
    * Updaters must be synchronous, deterministic, and side-effect-free. CAS-backed
    * clients may run an updater again when another writer wins the version race.
+   * A rejected promise does not prove that the mutation was rolled back: a
+   * connector may commit state and then fail while delivering its durable wake
+   * intents. Retrying is exactly-once only when the same `stepId` is supplied.
+   * Callers without a `stepId` must read and reconcile instead of blindly retrying.
    *
    * When `stepId` is provided the update is exactly-once per
    * (executionId, stepKey): the committed StoreUpdateResult is recorded in
@@ -336,11 +340,11 @@ export abstract class CasStoreClient extends StoreClient {
       return applied.result as StoreUpdateResult<StoreState<Schema>>;
     }
 
+    let snapshot = await this.getStore({
+      definition: params.definition,
+      id: params.id,
+    });
     while (true) {
-      const snapshot = await this.getStore({
-        definition: params.definition,
-        id: params.id,
-      });
       const prepared = await prepareStoreUpdate(
         params.definition,
         snapshot,
@@ -365,6 +369,9 @@ export abstract class CasStoreClient extends StoreClient {
       if (committed.status === "already-applied") {
         return committed.result as StoreUpdateResult<StoreState<Schema>>;
       }
+      snapshot = committed.snapshot as StoreSnapshot<StoreState<Schema>>;
+      // TODO: add a configurable retry cap/backoff policy before remote CAS
+      // connectors are introduced; SQLite serializes commits locally.
     }
   }
 
@@ -379,6 +386,8 @@ export abstract class CasStoreClient extends StoreClient {
     if (applied) {
       return normalizeUpdateFromResult<StoreState<Schema>>(applied.result);
     }
+
+    assertStoreSnapshotInstanceId(params.snapshot);
 
     const current = await this.getStore({
       definition: params.definition,
@@ -429,11 +438,11 @@ export abstract class CasStoreClient extends StoreClient {
     const applied = await this.getAppliedResult(params);
     if (applied) return applied.result as StoreTakeResult<R>;
 
+    let snapshot = await this.getStore({
+      definition: params.definition,
+      id: params.id,
+    });
     while (true) {
-      const snapshot = await this.getStore({
-        definition: params.definition,
-        id: params.id,
-      });
       const previousState = cloneStoreState(snapshot.state);
       const draft = cloneStoreState(previousState) as Draft<StoreState<Schema>>;
       const tracked = trackStoreUpdater(draft);
@@ -479,6 +488,8 @@ export abstract class CasStoreClient extends StoreClient {
       if (committed.status === "already-applied") {
         return committed.result as StoreTakeResult<R>;
       }
+      snapshot = committed.snapshot as StoreSnapshot<StoreState<Schema>>;
+      // TODO: share the configurable retry cap/backoff policy with updateStore.
     }
   }
 
@@ -527,6 +538,14 @@ function sameStoreVersion(
   return (
     left.instanceId === right.instanceId && left.version === right.version
   );
+}
+
+function assertStoreSnapshotInstanceId(snapshot: { instanceId?: string }) {
+  if (!snapshot.instanceId) {
+    throw new Error(
+      "Store snapshot is missing instanceId; read a fresh snapshot"
+    );
+  }
 }
 
 function storeUpdateConflict(

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -137,14 +137,27 @@ export type StoreWaiter = {
   readPaths: StorePath[];
 };
 
+export type StoreMutationCommitResult =
+  | { status: "committed" }
+  | { status: "already-applied"; result: unknown }
+  | { status: "conflict"; snapshot: StoreSnapshot<unknown> };
+
+export type StoreMutation = {
+  definition: StoreDefinition;
+  id: string;
+  expected: StoreSnapshot<unknown>;
+  nextState: unknown;
+  changedPaths: StorePath[];
+  stepId?: StoreStepId;
+  result: unknown;
+};
+
 export type RuntimeStore<T> = {
   get(): Promise<StoreSnapshot<T>>;
-  update(
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
-  ): Promise<StoreUpdateResult<T>>;
+  update(updater: (draft: Draft<T>) => void | T): Promise<StoreUpdateResult<T>>;
   updateFrom(
     snapshot: StoreSnapshot<T>,
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+    updater: (draft: Draft<T>) => void | T
   ): Promise<StoreUpdateFromResult<T>>;
   deleteFrom(snapshot: StoreSnapshot<T>): Promise<StoreDeleteFromResult>;
 };
@@ -204,9 +217,8 @@ export abstract class StoreClient {
 
   /**
    * Updates a store's state atomically.
-   * NOTE: Updaters should ideally be synchronous. Although the signature allows async updaters,
-   * holding open transactions (e.g. SQLite BEGIN IMMEDIATE) across long-running async steps
-   * will block other clients from writing. Avoid network, timers, or other async tasks in updaters.
+   * Updaters must be synchronous, deterministic, and side-effect-free. CAS-backed
+   * clients may run an updater again when another writer wins the version race.
    *
    * When `stepId` is provided the update is exactly-once per
    * (executionId, stepKey): the committed StoreUpdateResult is recorded in
@@ -217,15 +229,14 @@ export abstract class StoreClient {
   abstract updateStore<Schema extends StandardSchemaV1>(params: {
     definition: StoreDefinition<Schema>;
     id: string;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
     stepId?: StoreStepId;
   }): Promise<StoreUpdateResult<StoreState<Schema>>>;
 
   /**
    * Updates a store only if it has not changed since `snapshot` was read.
-   * A conflict does not run the updater or change the store. When `stepId`
+   * A conflict does not change the store, though a racing writer may cause a
+   * pure updater to have been evaluated before the conflict is observed. When `stepId`
    * identifies an update that already committed, its recorded result wins
    * over the version check so replay remains exactly-once.
    */
@@ -233,16 +244,14 @@ export abstract class StoreClient {
     definition: StoreDefinition<Schema>;
     id: string;
     snapshot: StoreSnapshot<StoreState<Schema>>;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
     stepId?: StoreStepId;
   }): Promise<StoreUpdateFromResult<StoreState<Schema>>>;
 
   /**
-   * Atomically selects and claims from a store. The selector and claim
-   * mutation run inside the SAME store update transaction, committing as a
-   * single version bump. If the selector does not match, nothing is
+   * Atomically selects and claims from a store. The selector and claim run
+   * locally against a snapshot, then commit with a single conditional version
+   * bump. A conflict re-runs both functions against the new snapshot. If the selector does not match, nothing is
    * committed and the store's current version plus the selector's tracked
    * read paths are returned so the caller can register a waiter with the
    * correct sinceVersion (closing the lost-wakeup gap by construction).
@@ -296,6 +305,252 @@ export abstract class StoreClient {
   }): Promise<StoreDeleteFromResult>;
 }
 
+/**
+ * Implements store transformations as read/compute/compare-and-swap loops.
+ * Storage connectors only implement the atomic mutation protocol and never
+ * execute application callbacks while holding a storage transaction.
+ */
+export abstract class CasStoreClient extends StoreClient {
+  protected abstract getAppliedStoreStep(params: {
+    definition: StoreDefinition;
+    id: string;
+    stepId: StoreStepId;
+  }): Promise<{ result: unknown } | undefined>;
+
+  /**
+   * Atomically compares `expected`, writes the next state, records the step
+   * result, and persists the changed paths for durable wake delivery.
+   */
+  protected abstract commitStoreMutation(
+    mutation: StoreMutation
+  ): Promise<StoreMutationCommitResult>;
+
+  async updateStore<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
+    stepId?: StoreStepId;
+  }): Promise<StoreUpdateResult<StoreState<Schema>>> {
+    const applied = await this.getAppliedResult(params);
+    if (applied) {
+      return applied.result as StoreUpdateResult<StoreState<Schema>>;
+    }
+
+    while (true) {
+      const snapshot = await this.getStore({
+        definition: params.definition,
+        id: params.id,
+      });
+      const prepared = await prepareStoreUpdate(
+        params.definition,
+        snapshot,
+        params.updater
+      );
+      const result: StoreUpdateResult<StoreState<Schema>> = {
+        state: cloneStoreState(prepared.nextState),
+        previousVersion: snapshot.version,
+        version: snapshot.version + 1,
+      };
+      const committed = await this.commitStoreMutation({
+        definition: params.definition,
+        id: params.id,
+        expected: snapshot,
+        nextState: prepared.nextState,
+        changedPaths: prepared.changedPaths,
+        stepId: params.stepId,
+        result,
+      });
+
+      if (committed.status === "committed") return result;
+      if (committed.status === "already-applied") {
+        return committed.result as StoreUpdateResult<StoreState<Schema>>;
+      }
+    }
+  }
+
+  async updateStoreFrom<Schema extends StandardSchemaV1>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    snapshot: StoreSnapshot<StoreState<Schema>>;
+    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
+    stepId?: StoreStepId;
+  }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
+    const applied = await this.getAppliedResult(params);
+    if (applied) {
+      return normalizeUpdateFromResult<StoreState<Schema>>(applied.result);
+    }
+
+    const current = await this.getStore({
+      definition: params.definition,
+      id: params.id,
+    });
+    if (!sameStoreVersion(current, params.snapshot)) {
+      return storeUpdateConflict(params.snapshot, current);
+    }
+
+    const prepared = await prepareStoreUpdate(
+      params.definition,
+      params.snapshot,
+      params.updater
+    );
+    const result: StoreUpdateFromResult<StoreState<Schema>> = {
+      updated: true,
+      state: cloneStoreState(prepared.nextState),
+      previousVersion: params.snapshot.version,
+      version: params.snapshot.version + 1,
+    };
+    const committed = await this.commitStoreMutation({
+      definition: params.definition,
+      id: params.id,
+      expected: params.snapshot,
+      nextState: prepared.nextState,
+      changedPaths: prepared.changedPaths,
+      stepId: params.stepId,
+      result,
+    });
+
+    if (committed.status === "committed") return result;
+    if (committed.status === "already-applied") {
+      return normalizeUpdateFromResult<StoreState<Schema>>(committed.result);
+    }
+    return storeUpdateConflict(params.snapshot, committed.snapshot);
+  }
+
+  async takeFromStore<Schema extends StandardSchemaV1, R>(params: {
+    definition: StoreDefinition<Schema>;
+    id: string;
+    selector: StoreSelector<StoreState<Schema>, R>;
+    claim: (
+      draft: Draft<StoreState<Schema>>,
+      selected: NonNullable<R>
+    ) => void;
+    stepId?: StoreStepId;
+  }): Promise<StoreTakeResult<R>> {
+    const applied = await this.getAppliedResult(params);
+    if (applied) return applied.result as StoreTakeResult<R>;
+
+    while (true) {
+      const snapshot = await this.getStore({
+        definition: params.definition,
+        id: params.id,
+      });
+      const previousState = cloneStoreState(snapshot.state);
+      const draft = cloneStoreState(previousState) as Draft<StoreState<Schema>>;
+      const tracked = trackStoreUpdater(draft);
+      const { result: selectedResult, readPaths } = trackStoreSelector(
+        tracked.draft as StoreState<Schema>,
+        params.selector
+      );
+
+      if (!isStoreSelectorMatch(selectedResult)) {
+        return {
+          matched: false,
+          instanceId: snapshot.instanceId,
+          version: snapshot.version,
+          readPaths,
+        };
+      }
+
+      const selected = unwrapTrackedValue(selectedResult) as NonNullable<R>;
+      assertSynchronousClaim(params.claim(tracked.draft, selected));
+      const nextState = await validateStoreState(params.definition, draft);
+      const selectedSnapshot = cloneStoreState(selected);
+      const changedPaths =
+        (nextState as unknown) === draft
+          ? tracked.writePaths()
+          : diffStorePaths(previousState, nextState);
+      const result: StoreTakeResult<R> = {
+        matched: true,
+        selected: selectedSnapshot,
+        instanceId: snapshot.instanceId,
+        version: snapshot.version + 1,
+      };
+      const committed = await this.commitStoreMutation({
+        definition: params.definition,
+        id: params.id,
+        expected: snapshot,
+        nextState,
+        changedPaths,
+        stepId: params.stepId,
+        result,
+      });
+
+      if (committed.status === "committed") return result;
+      if (committed.status === "already-applied") {
+        return committed.result as StoreTakeResult<R>;
+      }
+    }
+  }
+
+  private getAppliedResult(params: {
+    definition: StoreDefinition;
+    id: string;
+    stepId?: StoreStepId;
+  }) {
+    return params.stepId
+      ? this.getAppliedStoreStep({
+          definition: params.definition,
+          id: params.id,
+          stepId: params.stepId,
+        })
+      : Promise.resolve(undefined);
+  }
+}
+
+async function prepareStoreUpdate<Schema extends StandardSchemaV1>(
+  definition: StoreDefinition<Schema>,
+  snapshot: StoreSnapshot<StoreState<Schema>>,
+  updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>
+) {
+  const previousState = cloneStoreState(snapshot.state);
+  const draft = cloneStoreState(previousState) as Draft<StoreState<Schema>>;
+  const tracked = trackStoreUpdater(draft);
+  const updated = updater(tracked.draft);
+  assertSynchronousUpdater(updated);
+  const returned = updated === undefined ? undefined : unwrapTrackedValue(updated);
+  const isReplacement = returned !== undefined && returned !== draft;
+  const nextState = await validateStoreState(
+    definition,
+    isReplacement ? returned : draft
+  );
+  const changedPaths =
+    !isReplacement && (nextState as unknown) === draft
+      ? tracked.writePaths()
+      : diffStorePaths(previousState, nextState);
+  return { nextState, changedPaths };
+}
+
+function sameStoreVersion(
+  left: StoreSnapshot<unknown>,
+  right: StoreSnapshot<unknown>
+) {
+  return (
+    left.instanceId === right.instanceId && left.version === right.version
+  );
+}
+
+function storeUpdateConflict(
+  expected: StoreSnapshot<unknown>,
+  actual: StoreSnapshot<unknown>
+): Extract<StoreUpdateFromResult<never>, { updated: false }> {
+  return {
+    updated: false,
+    expectedInstanceId: expected.instanceId,
+    actualInstanceId: actual.instanceId,
+    expectedVersion: expected.version,
+    actualVersion: actual.version,
+  };
+}
+
+function normalizeUpdateFromResult<T>(
+  result: unknown
+): StoreUpdateFromResult<T> {
+  const recorded = result as StoreUpdateFromResult<T> | StoreUpdateResult<T>;
+  return "updated" in recorded
+    ? recorded
+    : { updated: true, ...recorded };
+}
+
 export function isStoreSelectorMatch<R>(
   result: R
 ): result is Exclude<R, undefined | null | false> {
@@ -308,6 +563,15 @@ export function assertSynchronousClaim(claimResult: unknown): void {
     typeof (claimResult as PromiseLike<unknown>).then === "function"
   ) {
     throw new Error("Store take claims must be synchronous");
+  }
+}
+
+export function assertSynchronousUpdater(updaterResult: unknown): void {
+  if (
+    updaterResult &&
+    typeof (updaterResult as PromiseLike<unknown>).then === "function"
+  ) {
+    throw new Error("Store updaters must be synchronous");
   }
 }
 

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -462,12 +462,13 @@ export abstract class CasStoreClient extends StoreClient {
 
       const selected = unwrapTrackedValue(selectedResult) as NonNullable<R>;
       assertSynchronousClaim(params.claim(tracked.draft, selected));
-      const nextState = await validateStoreState(params.definition, draft);
+      const prepared = await finalizeStoreMutation({
+        definition: params.definition,
+        previousState,
+        draft,
+        tracked,
+      });
       const selectedSnapshot = cloneStoreState(selected);
-      const changedPaths =
-        (nextState as unknown) === draft
-          ? tracked.writePaths()
-          : diffStorePaths(previousState, nextState);
       const result: StoreTakeResult<R> = {
         matched: true,
         selected: selectedSnapshot,
@@ -478,8 +479,8 @@ export abstract class CasStoreClient extends StoreClient {
         definition: params.definition,
         id: params.id,
         expected: snapshot,
-        nextState,
-        changedPaths,
+        nextState: prepared.nextState,
+        changedPaths: prepared.changedPaths,
         stepId: params.stepId,
         result,
       });
@@ -519,15 +520,32 @@ async function prepareStoreUpdate<Schema extends StandardSchemaV1>(
   const updated = updater(tracked.draft);
   assertSynchronousUpdater(updated);
   const returned = updated === undefined ? undefined : unwrapTrackedValue(updated);
-  const isReplacement = returned !== undefined && returned !== draft;
-  const nextState = await validateStoreState(
+  return finalizeStoreMutation({
     definition,
-    isReplacement ? returned : draft
+    previousState,
+    draft,
+    tracked,
+    replacement: returned,
+  });
+}
+
+async function finalizeStoreMutation<Schema extends StandardSchemaV1>(params: {
+  definition: StoreDefinition<Schema>;
+  previousState: StoreState<Schema>;
+  draft: Draft<StoreState<Schema>>;
+  tracked: TrackedStoreUpdater<Draft<StoreState<Schema>>>;
+  replacement?: unknown;
+}) {
+  const isReplacement =
+    params.replacement !== undefined && params.replacement !== params.draft;
+  const nextState = await validateStoreState(
+    params.definition,
+    isReplacement ? params.replacement : params.draft
   );
   const changedPaths =
-    !isReplacement && (nextState as unknown) === draft
-      ? tracked.writePaths()
-      : diffStorePaths(previousState, nextState);
+    !isReplacement && (nextState as unknown) === params.draft
+      ? params.tracked.writePaths()
+      : diffStorePaths(params.previousState, nextState);
   return { nextState, changedPaths };
 }
 

--- a/packages/core/src/base/store.ts
+++ b/packages/core/src/base/store.ts
@@ -384,7 +384,7 @@ export abstract class CasStoreClient extends StoreClient {
   }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
     const applied = await this.getAppliedResult(params);
     if (applied) {
-      return normalizeUpdateFromResult<StoreState<Schema>>(applied.result);
+      return applied.result as StoreUpdateFromResult<StoreState<Schema>>;
     }
 
     assertStoreSnapshotInstanceId(params.snapshot);
@@ -420,7 +420,7 @@ export abstract class CasStoreClient extends StoreClient {
 
     if (committed.status === "committed") return result;
     if (committed.status === "already-applied") {
-      return normalizeUpdateFromResult<StoreState<Schema>>(committed.result);
+      return committed.result as StoreUpdateFromResult<StoreState<Schema>>;
     }
     return storeUpdateConflict(params.snapshot, committed.snapshot);
   }
@@ -579,15 +579,6 @@ function storeUpdateConflict(
   };
 }
 
-function normalizeUpdateFromResult<T>(
-  result: unknown
-): StoreUpdateFromResult<T> {
-  const recorded = result as StoreUpdateFromResult<T> | StoreUpdateResult<T>;
-  return "updated" in recorded
-    ? recorded
-    : { updated: true, ...recorded };
-}
-
 export function isStoreSelectorMatch<R>(
   result: R
 ): result is Exclude<R, undefined | null | false> {
@@ -641,10 +632,8 @@ export function cloneStoreState<T>(state: T): T {
 /**
  * Diffs two store states and returns the set of changed paths.
  *
- * This is O(total state size), so it is no longer the primary source of
- * changed paths – `trackStoreUpdater` records write paths in O(changes)
- * while the updater runs. The diff remains as the fallback for the cases a
- * recording proxy cannot observe:
+ * This is O(total state size). `trackStoreUpdater` records ordinary mutation
+ * paths in O(changes); the diff handles cases a recording proxy cannot observe:
  * - the updater RETURNED a replacement state instead of mutating the draft
  * - schema validation returned a transformed copy of the draft
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,11 +19,15 @@ export type {
   StoreUpdateResult,
   StoreVersion,
   StoreWaiter,
+  StoreMutation,
+  StoreMutationCommitResult,
   TrackedStoreUpdater,
 } from "./base/store";
 export {
   StoreClient,
+  CasStoreClient,
   assertSynchronousClaim,
+  assertSynchronousUpdater,
   cloneStoreState,
   defineStore,
   diffStorePaths,

--- a/packages/test-runtime/src/memory-store.test.ts
+++ b/packages/test-runtime/src/memory-store.test.ts
@@ -105,7 +105,7 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
   expect(events).toEqual([]);
 });
 
-test("concurrent async updaters both commit", async () => {
+test("concurrent synchronous updates both commit", async () => {
   const { client } = createClient();
 
   await client.getOrCreateStore({
@@ -118,16 +118,14 @@ test("concurrent async updaters both commit", async () => {
     client.updateStore({
       definition: Store,
       id: "race",
-      async updater(draft) {
-        await Promise.resolve();
+      updater(draft) {
         draft.messages.push({ id: "msg-a" });
       },
     }),
     client.updateStore({
       definition: Store,
       id: "race",
-      async updater(draft) {
-        await Promise.resolve();
+      updater(draft) {
         draft.messages.push({ id: "msg-b" });
       },
     }),

--- a/packages/test-runtime/src/memory-store.test.ts
+++ b/packages/test-runtime/src/memory-store.test.ts
@@ -4,12 +4,14 @@ import {
   defineStore,
   type SchedulerClient,
   type StandardSchemaV1,
+  type StorePath,
   type WorkflowEvent,
 } from "@yieldstar/core";
 import { MemoryStoreClient } from "./memory-store";
 
 type State = {
   messages: { id: string }[];
+  unrelated?: number;
 };
 
 const Store = defineStore("memory-test", schema<State>());
@@ -61,7 +63,7 @@ test("memory store updates wake matching waiters", async () => {
   expect(events).toEqual([event]);
 });
 
-test("failed wake delivery keeps the waiter and does not reject the committed mutation", async () => {
+test("an unrelated mutation retries failed wake delivery", async () => {
   const events: WorkflowEvent[] = [];
   let wakeAttempts = 0;
   let updaterRuns = 0;
@@ -117,7 +119,7 @@ test("failed wake delivery keeps the waiter and does not reject the committed mu
       definition: Store,
       id: "wake-retry",
       updater(draft) {
-        draft.messages.push({ id: "msg-2" });
+        draft.unrelated = 1;
       },
     });
     expect(wakeAttempts).toBe(2);
@@ -127,10 +129,87 @@ test("failed wake delivery keeps the waiter and does not reject the committed mu
       definition: Store,
       id: "wake-retry",
       updater(draft) {
-        draft.messages.push({ id: "msg-3" });
+        draft.messages.push({ id: "msg-2" });
       },
     });
     expect(wakeAttempts).toBe(2);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    errorSpy.mockRestore();
+  }
+});
+
+test("recreated stores do not inherit pending wakes from deleted waiters", async () => {
+  const events: WorkflowEvent[] = [];
+  let wakeAttempts = 0;
+  const client = new MemoryStoreClient({
+    schedulerClient: {
+      async requestWakeUp(wakeEvent) {
+        wakeAttempts++;
+        if (wakeAttempts === 1) throw new Error("wake delivery failed");
+        events.push(wakeEvent);
+      },
+    },
+  });
+  const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+  try {
+    const original = await client.getOrCreateStore({
+      definition: Store,
+      id: "recreated-wake",
+      initial: { messages: [] },
+    });
+    const waiter = {
+      workflowId: event.workflowId,
+      executionId: event.executionId,
+      stepKey: "next-message",
+      event,
+      storeName: Store.name,
+      storeId: "recreated-wake",
+      instanceId: original.instanceId,
+      sinceVersion: 0,
+      readPaths: [["messages"]] as StorePath[],
+    };
+    await client.registerWaiter(waiter);
+    await client.updateStore({
+      definition: Store,
+      id: "recreated-wake",
+      updater(draft) {
+        draft.messages.push({ id: "old-instance" });
+      },
+    });
+    expect(wakeAttempts).toBe(1);
+
+    await client.deleteStore({ definition: Store, id: "recreated-wake" });
+    const recreated = await client.getOrCreateStore({
+      definition: Store,
+      id: "recreated-wake",
+      initial: { messages: [] },
+    });
+    await client.registerWaiter({
+      ...waiter,
+      instanceId: recreated.instanceId,
+    });
+
+    await client.updateStore({
+      definition: Store,
+      id: "recreated-wake",
+      updater(draft) {
+        draft.unrelated = 1;
+      },
+    });
+    expect(wakeAttempts).toBe(1);
+    expect(events).toEqual([]);
+
+    await client.updateStore({
+      definition: Store,
+      id: "recreated-wake",
+      updater(draft) {
+        draft.messages.push({ id: "new-instance" });
+      },
+    });
+    expect(wakeAttempts).toBe(2);
+    expect(events).toEqual([event]);
     expect(errorSpy).toHaveBeenCalledTimes(1);
   } finally {
     errorSpy.mockRestore();
@@ -227,7 +306,7 @@ test("failed stale-waiter delivery remains registered for a later mutation", asy
       definition: Store,
       id: "stale-wake-retry",
       updater(draft) {
-        draft.messages.push({ id: "msg-2" });
+        draft.unrelated = 1;
       },
     });
     expect(wakeAttempts).toBe(2);

--- a/packages/test-runtime/src/memory-store.test.ts
+++ b/packages/test-runtime/src/memory-store.test.ts
@@ -61,6 +61,82 @@ test("memory store updates wake matching waiters", async () => {
   expect(events).toEqual([event]);
 });
 
+test("failed wake delivery keeps the waiter and does not reject the committed mutation", async () => {
+  const events: WorkflowEvent[] = [];
+  let wakeAttempts = 0;
+  let updaterRuns = 0;
+  const client = new MemoryStoreClient({
+    schedulerClient: {
+      async requestWakeUp(wakeEvent) {
+        wakeAttempts++;
+        if (wakeAttempts === 1) throw new Error("wake delivery failed");
+        events.push(wakeEvent);
+      },
+    },
+  });
+  const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+  try {
+    const initial = await client.getOrCreateStore({
+      definition: Store,
+      id: "wake-retry",
+      initial: { messages: [] },
+    });
+    await client.registerWaiter({
+      workflowId: event.workflowId,
+      executionId: event.executionId,
+      stepKey: "next-message",
+      event,
+      storeName: Store.name,
+      storeId: "wake-retry",
+      instanceId: initial.instanceId,
+      sinceVersion: 0,
+      readPaths: [["messages"]],
+    });
+
+    const updateOnce = () =>
+      client.updateStore({
+        definition: Store,
+        id: "wake-retry",
+        stepId: { executionId: "execution", stepKey: "wake-retry" },
+        updater(draft) {
+          updaterRuns++;
+          draft.messages.push({ id: "msg-1" });
+        },
+      });
+    const committed = await updateOnce();
+    expect(committed.version).toBe(1);
+    expect(wakeAttempts).toBe(1);
+    expect(events).toEqual([]);
+
+    expect(await updateOnce()).toEqual(committed);
+    expect(updaterRuns).toBe(1);
+    expect(wakeAttempts).toBe(1);
+
+    await client.updateStore({
+      definition: Store,
+      id: "wake-retry",
+      updater(draft) {
+        draft.messages.push({ id: "msg-2" });
+      },
+    });
+    expect(wakeAttempts).toBe(2);
+    expect(events).toEqual([event]);
+
+    await client.updateStore({
+      definition: Store,
+      id: "wake-retry",
+      updater(draft) {
+        draft.messages.push({ id: "msg-3" });
+      },
+    });
+    expect(wakeAttempts).toBe(2);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    errorSpy.mockRestore();
+  }
+});
+
 test("registering a waiter with a stale sinceVersion triggers an immediate wake", async () => {
   const { client, events } = createClient();
 
@@ -103,6 +179,63 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
     },
   });
   expect(events).toEqual([]);
+});
+
+test("failed stale-waiter delivery remains registered for a later mutation", async () => {
+  const events: WorkflowEvent[] = [];
+  let wakeAttempts = 0;
+  const client = new MemoryStoreClient({
+    schedulerClient: {
+      async requestWakeUp(wakeEvent) {
+        wakeAttempts++;
+        if (wakeAttempts === 1) throw new Error("wake delivery failed");
+        events.push(wakeEvent);
+      },
+    },
+  });
+  const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+  try {
+    const initial = await client.getOrCreateStore({
+      definition: Store,
+      id: "stale-wake-retry",
+      initial: { messages: [] },
+    });
+    await client.updateStore({
+      definition: Store,
+      id: "stale-wake-retry",
+      updater(draft) {
+        draft.messages.push({ id: "msg-1" });
+      },
+    });
+
+    await client.registerWaiter({
+      workflowId: event.workflowId,
+      executionId: event.executionId,
+      stepKey: "next-message",
+      event,
+      storeName: Store.name,
+      storeId: "stale-wake-retry",
+      instanceId: initial.instanceId,
+      sinceVersion: 0,
+      readPaths: [["messages"]],
+    });
+    expect(wakeAttempts).toBe(1);
+    expect(events).toEqual([]);
+
+    await client.updateStore({
+      definition: Store,
+      id: "stale-wake-retry",
+      updater(draft) {
+        draft.messages.push({ id: "msg-2" });
+      },
+    });
+    expect(wakeAttempts).toBe(2);
+    expect(events).toEqual([event]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  } finally {
+    errorSpy.mockRestore();
+  }
 });
 
 test("concurrent synchronous updates retry CAS conflicts and both commit", async () => {

--- a/packages/test-runtime/src/memory-store.test.ts
+++ b/packages/test-runtime/src/memory-store.test.ts
@@ -105,8 +105,9 @@ test("registering a waiter with a stale sinceVersion triggers an immediate wake"
   expect(events).toEqual([]);
 });
 
-test("concurrent synchronous updates both commit", async () => {
+test("concurrent synchronous updates retry CAS conflicts and both commit", async () => {
   const { client } = createClient();
+  let updaterRuns = 0;
 
   await client.getOrCreateStore({
     definition: Store,
@@ -119,6 +120,7 @@ test("concurrent synchronous updates both commit", async () => {
       definition: Store,
       id: "race",
       updater(draft) {
+        updaterRuns++;
         draft.messages.push({ id: "msg-a" });
       },
     }),
@@ -126,12 +128,14 @@ test("concurrent synchronous updates both commit", async () => {
       definition: Store,
       id: "race",
       updater(draft) {
+        updaterRuns++;
         draft.messages.push({ id: "msg-b" });
       },
     }),
   ]);
 
   expect([first.version, second.version].sort()).toEqual([1, 2]);
+  expect(updaterRuns).toBe(3);
 
   const snapshot = await client.getStore({ definition: Store, id: "race" });
   expect(snapshot.version).toBe(2);

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -1,28 +1,18 @@
 import type { SchedulerClient } from "@yieldstar/core";
 import {
-  assertSynchronousClaim,
-  assertSynchronousUpdater,
+  CasStoreClient,
   cloneStoreState,
-  diffStorePaths,
-  isStoreSelectorMatch,
-  StoreClient,
   storePathsIntersect,
-  trackStoreSelector,
-  trackStoreUpdater,
-  unwrapTrackedValue,
   validateStoreState,
-  type Draft,
   type StandardSchemaV1,
   type StoreDefinition,
   type StoreDeleteFromResult,
+  type StoreMutation,
+  type StoreMutationCommitResult,
   type StorePath,
-  type StoreSelector,
   type StoreSnapshot,
   type StoreState,
   type StoreStepId,
-  type StoreTakeResult,
-  type StoreUpdateFromResult,
-  type StoreUpdateResult,
   type StoreWaiter,
 } from "@yieldstar/core";
 
@@ -32,7 +22,7 @@ type StoreRecord = {
   version: number;
 };
 
-export class MemoryStoreClient extends StoreClient {
+export class MemoryStoreClient extends CasStoreClient {
   private stores = new Map<string, StoreRecord>();
   private waiters = new Map<string, StoreWaiter>();
   // Applied-steps ledger: (storeName, storeId, executionId, stepKey) ->
@@ -125,291 +115,84 @@ export class MemoryStoreClient extends StoreClient {
     };
   }
 
-  async updateStore<Schema extends StandardSchemaV1>(params: {
-    definition: StoreDefinition<Schema>;
+  protected async getAppliedStoreStep(params: {
+    definition: StoreDefinition;
     id: string;
-    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
-    stepId?: StoreStepId;
-  }): Promise<StoreUpdateResult<StoreState<Schema>>> {
-    return (await this.updateStoreInternal(params)) as StoreUpdateResult<
-      StoreState<Schema>
-    >;
+    stepId: StoreStepId;
+  }): Promise<{ result: unknown } | undefined> {
+    const applied = this.appliedSteps.get(
+      this.appliedStepKey(params.definition.name, params.id, params.stepId)
+    );
+    return applied ? { result: JSON.parse(applied) } : undefined;
   }
 
-  async updateStoreFrom<Schema extends StandardSchemaV1>(params: {
-    definition: StoreDefinition<Schema>;
-    id: string;
-    snapshot: StoreSnapshot<StoreState<Schema>>;
-    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
-    stepId?: StoreStepId;
-  }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
-    const result = await this.updateStoreInternal({
-      ...params,
-      expectedInstanceId: params.snapshot.instanceId,
-      expectedVersion: params.snapshot.version,
-    });
-    return "updated" in result ? result : { updated: true, ...result };
-  }
-
-  private updateStoreInternal<Schema extends StandardSchemaV1>(params: {
-    definition: StoreDefinition<Schema>;
-    id: string;
-    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
-    stepId?: StoreStepId;
-    expectedInstanceId?: string;
-    expectedVersion?: number;
-  }): Promise<
-    | StoreUpdateResult<StoreState<Schema>>
-    | Extract<StoreUpdateFromResult<StoreState<Schema>>, { updated: false }>
-  > {
+  protected commitStoreMutation(
+    mutation: StoreMutation
+  ): Promise<StoreMutationCommitResult> {
     return this.enqueueWrite(async () => {
-      const key = this.storeKey(params.definition.name, params.id);
-
-      // Exactly-once: if this workflow step already committed, return the
-      // recorded result without re-running the updater.
-      if (params.stepId) {
+      if (mutation.stepId) {
         const applied = this.appliedSteps.get(
-          this.appliedStepKey(params.definition.name, params.id, params.stepId)
+          this.appliedStepKey(
+            mutation.definition.name,
+            mutation.id,
+            mutation.stepId
+          )
         );
         if (applied) {
-          return JSON.parse(applied) as StoreUpdateResult<StoreState<Schema>>;
+          return {
+            status: "already-applied",
+            result: JSON.parse(applied),
+          };
         }
       }
 
-      if (params.expectedVersion !== undefined) {
-        this.assertSnapshotHasInstanceId({
-          instanceId: params.expectedInstanceId,
-        });
-      }
-
+      const key = this.storeKey(mutation.definition.name, mutation.id);
       const record = this.stores.get(key);
       if (!record) {
         throw new Error(
-          `Store "${params.definition.name}:${params.id}" does not exist`
+          `Store "${mutation.definition.name}:${mutation.id}" does not exist`
         );
       }
-
       if (
-        params.expectedInstanceId !== undefined &&
-        params.expectedVersion !== undefined &&
-        (record.instanceId !== params.expectedInstanceId ||
-          record.version !== params.expectedVersion)
+        record.instanceId !== mutation.expected.instanceId ||
+        record.version !== mutation.expected.version
       ) {
         return {
-          updated: false as const,
-          expectedInstanceId: params.expectedInstanceId,
-          actualInstanceId: record.instanceId,
-          expectedVersion: params.expectedVersion,
-          actualVersion: record.version,
+          status: "conflict",
+          snapshot: {
+            state: cloneStoreState(record.state),
+            instanceId: record.instanceId,
+            version: record.version,
+          },
         };
       }
 
-      const previousState = cloneStoreState(
-        record.state
-      ) as StoreState<Schema>;
-      const draft = cloneStoreState(previousState) as Draft<
-        StoreState<Schema>
-      >;
-      // The updater runs against a write-recording proxy so changed paths
-      // are derived from its mutations in O(changes) – the full-state deep
-      // diff is only needed when the updater returns a replacement state
-      // (or validation returns a transformed copy).
-      const tracked = trackStoreUpdater(draft);
-      const updated = params.updater(tracked.draft);
-      assertSynchronousUpdater(updated);
-      const returned =
-        updated === undefined ? undefined : unwrapTrackedValue(updated);
-      const isReplacement = returned !== undefined && returned !== draft;
-      const nextState = await validateStoreState(
-        params.definition,
-        isReplacement ? returned : draft
-      );
-      const changedPaths =
-        !isReplacement && (nextState as unknown) === draft
-          ? tracked.writePaths()
-          : diffStorePaths(previousState, nextState);
-      const version = await this.commitNextState({
-        key,
-        storeName: params.definition.name,
-        storeId: params.id,
+      const version = record.version + 1;
+      this.stores.set(key, {
+        state: cloneStoreState(mutation.nextState),
         instanceId: record.instanceId,
-        changedPaths,
-        nextState,
-        previousVersion: record.version,
-        // Recorded in the same critical section as the state commit
-        appliedStep: params.stepId
-          ? {
-              key: this.appliedStepKey(
-                params.definition.name,
-                params.id,
-                params.stepId
-              ),
-              result: JSON.stringify({
-                state: nextState,
-                previousVersion: record.version,
-                version: record.version + 1,
-              }),
-            }
-          : undefined,
+        version,
       });
 
-      return {
-        state: cloneStoreState(nextState),
-        previousVersion: record.version,
-        version,
-      };
-    });
-  }
-
-  async takeFromStore<Schema extends StandardSchemaV1, R>(params: {
-    definition: StoreDefinition<Schema>;
-    id: string;
-    selector: StoreSelector<StoreState<Schema>, R>;
-    claim: (
-      draft: Draft<StoreState<Schema>>,
-      selected: NonNullable<R>
-    ) => void;
-    stepId?: StoreStepId;
-  }): Promise<StoreTakeResult<R>> {
-    return this.enqueueWrite(async () => {
-      const key = this.storeKey(params.definition.name, params.id);
-
-      // Exactly-once: if this workflow step already committed a claim,
-      // return the recorded outcome without re-running selector/claim.
-      // Only matched takes are recorded – an unmatched take commits
-      // nothing and must be free to re-evaluate on the next wake.
-      if (params.stepId) {
-        const applied = this.appliedSteps.get(
-          this.appliedStepKey(params.definition.name, params.id, params.stepId)
-        );
-        if (applied) {
-          return JSON.parse(applied) as StoreTakeResult<R>;
-        }
-      }
-
-      const record = this.stores.get(key);
-      if (!record) {
-        throw new Error(
-          `Store "${params.definition.name}:${params.id}" does not exist`
+      if (mutation.stepId) {
+        this.appliedSteps.set(
+          this.appliedStepKey(
+            mutation.definition.name,
+            mutation.id,
+            mutation.stepId
+          ),
+          JSON.stringify(mutation.result)
         );
       }
 
-      const previousState = cloneStoreState(
-        record.state
-      ) as StoreState<Schema>;
-      const draft = cloneStoreState(previousState) as Draft<
-        StoreState<Schema>
-      >;
-      // Wrap the draft in a write-recording proxy so the claim's mutations
-      // produce the changed paths (O(changes) instead of a full-state diff).
-      const tracked = trackStoreUpdater(draft);
-
-      // Run the selector against the mutable draft (through the
-      // read-tracking proxy over the recording proxy) so a selected value
-      // that is a reference into state observes the claim mutation before
-      // it is snapshotted – and so mutations through it are recorded.
-      const { result: selectedResult, readPaths } = trackStoreSelector(
-        tracked.draft as StoreState<Schema>,
-        params.selector
-      );
-
-      if (!isStoreSelectorMatch(selectedResult)) {
-        return {
-          matched: false,
-          instanceId: record.instanceId,
-          version: record.version,
-          readPaths,
-        };
-      }
-
-      // Unwraps the selector proxy to the RECORDING proxy, so mutations via
-      // the selected reference are captured as write paths.
-      const selected = unwrapTrackedValue(selectedResult) as NonNullable<R>;
-
-      assertSynchronousClaim(
-        params.claim(tracked.draft as Draft<StoreState<Schema>>, selected)
-      );
-
-      const nextState = await validateStoreState(params.definition, draft);
-      // Snapshot AFTER the claim ran (and unwrap any tracking proxies) so a
-      // selected reference into state reflects the claim mutation.
-      const selectedSnapshot = cloneStoreState(selected);
-      const changedPaths =
-        (nextState as unknown) === draft
-          ? tracked.writePaths()
-          : diffStorePaths(previousState, nextState);
-
-      const version = await this.commitNextState({
-        key,
-        storeName: params.definition.name,
-        storeId: params.id,
-        instanceId: record.instanceId,
-        changedPaths,
-        nextState,
-        previousVersion: record.version,
-        // Recorded in the same critical section as the claim commit
-        appliedStep: params.stepId
-          ? {
-              key: this.appliedStepKey(
-                params.definition.name,
-                params.id,
-                params.stepId
-              ),
-              result: JSON.stringify({
-                matched: true,
-                selected: selectedSnapshot,
-                instanceId: record.instanceId,
-                version: record.version + 1,
-              }),
-            }
-          : undefined,
-      });
-
-      return {
-        matched: true,
-        selected: selectedSnapshot,
-        instanceId: record.instanceId,
+      await this.wakeWaiters({
+        storeName: mutation.definition.name,
+        storeId: mutation.id,
         version,
-      };
+        changedPaths: mutation.changedPaths,
+      });
+      return { status: "committed" };
     });
-  }
-
-  /**
-   * Commits the next state (version + 1) and wakes waiters matching the
-   * changed paths. Must be called while holding the write lock.
-   */
-  private async commitNextState(params: {
-    key: string;
-    storeName: string;
-    storeId: string;
-    instanceId: string;
-    changedPaths: StorePath[];
-    nextState: unknown;
-    previousVersion: number;
-    appliedStep?: { key: string; result: string };
-  }): Promise<number> {
-    const { changedPaths } = params;
-    const version = params.previousVersion + 1;
-
-    this.stores.set(params.key, {
-      state: cloneStoreState(params.nextState),
-      instanceId: params.instanceId,
-      version,
-    });
-
-    // Ledger entry lands in the same synchronous section as the state write
-    if (params.appliedStep) {
-      this.appliedSteps.set(params.appliedStep.key, params.appliedStep.result);
-    }
-
-    await this.wakeWaiters({
-      storeName: params.storeName,
-      storeId: params.storeId,
-      version,
-      changedPaths,
-    });
-
-    return version;
   }
 
   async listStores<Schema extends StandardSchemaV1>(

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -296,7 +296,8 @@ export class MemoryStoreClient extends CasStoreClient {
         record.instanceId !== waiter.instanceId ||
         record.version > waiter.sinceVersion
       ) {
-        await this.schedulerClient.requestWakeUp(waiter.event);
+        this.waiters.set(key, cloneStoreState(waiter));
+        await this.deliverWaiter(key, waiter);
         return;
       }
       this.waiters.set(key, cloneStoreState(waiter));
@@ -317,8 +318,18 @@ export class MemoryStoreClient extends CasStoreClient {
         continue;
       }
 
-      this.waiters.delete(key);
+      await this.deliverWaiter(key, waiter);
+    }
+  }
+
+  private async deliverWaiter(key: string, waiter: StoreWaiter) {
+    try {
       await this.schedulerClient.requestWakeUp(waiter.event);
+      this.waiters.delete(key);
+    } catch (error) {
+      // The waiter is the retryable wake intent for this non-durable store.
+      // Leave it registered so the next matching mutation retries delivery.
+      console.error("Failed to deliver pending store wake", error);
     }
   }
 

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -1,6 +1,7 @@
 import type { SchedulerClient } from "@yieldstar/core";
 import {
   assertSynchronousClaim,
+  assertSynchronousUpdater,
   cloneStoreState,
   diffStorePaths,
   isStoreSelectorMatch,
@@ -40,8 +41,7 @@ export class MemoryStoreClient extends StoreClient {
   // workflow step returns the recorded result instead of re-applying.
   private appliedSteps = new Map<string, string>();
   private schedulerClient: SchedulerClient;
-  // Serializes writes so concurrent async updaters can't interleave between
-  // reading a record's version and writing the incremented version back.
+  // Serializes writes so concurrent commits cannot interleave.
   private writeLock: Promise<unknown> = Promise.resolve();
 
   constructor(params: { schedulerClient: SchedulerClient }) {
@@ -128,9 +128,7 @@ export class MemoryStoreClient extends StoreClient {
   async updateStore<Schema extends StandardSchemaV1>(params: {
     definition: StoreDefinition<Schema>;
     id: string;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
     stepId?: StoreStepId;
   }): Promise<StoreUpdateResult<StoreState<Schema>>> {
     return (await this.updateStoreInternal(params)) as StoreUpdateResult<
@@ -142,9 +140,7 @@ export class MemoryStoreClient extends StoreClient {
     definition: StoreDefinition<Schema>;
     id: string;
     snapshot: StoreSnapshot<StoreState<Schema>>;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
     stepId?: StoreStepId;
   }): Promise<StoreUpdateFromResult<StoreState<Schema>>> {
     const result = await this.updateStoreInternal({
@@ -158,9 +154,7 @@ export class MemoryStoreClient extends StoreClient {
   private updateStoreInternal<Schema extends StandardSchemaV1>(params: {
     definition: StoreDefinition<Schema>;
     id: string;
-    updater: (
-      draft: Draft<StoreState<Schema>>
-    ) => void | StoreState<Schema> | Promise<void | StoreState<Schema>>;
+    updater: (draft: Draft<StoreState<Schema>>) => void | StoreState<Schema>;
     stepId?: StoreStepId;
     expectedInstanceId?: string;
     expectedVersion?: number;
@@ -221,7 +215,8 @@ export class MemoryStoreClient extends StoreClient {
       // diff is only needed when the updater returns a replacement state
       // (or validation returns a transformed copy).
       const tracked = trackStoreUpdater(draft);
-      const updated = await params.updater(tracked.draft);
+      const updated = params.updater(tracked.draft);
+      assertSynchronousUpdater(updated);
       const returned =
         updated === undefined ? undefined : unwrapTrackedValue(updated);
       const isReplacement = returned !== undefined && returned !== draft;

--- a/packages/test-runtime/src/memory-store.ts
+++ b/packages/test-runtime/src/memory-store.ts
@@ -25,6 +25,7 @@ type StoreRecord = {
 export class MemoryStoreClient extends CasStoreClient {
   private stores = new Map<string, StoreRecord>();
   private waiters = new Map<string, StoreWaiter>();
+  private pendingWakes = new Set<string>();
   // Applied-steps ledger: (storeName, storeId, executionId, stepKey) ->
   // serialized committed result. Written in the same synchronous critical
   // section (within the write queue) as the state commit, so a retried
@@ -185,12 +186,13 @@ export class MemoryStoreClient extends CasStoreClient {
         );
       }
 
-      await this.wakeWaiters({
+      this.enqueueMatchingWakes({
         storeName: mutation.definition.name,
         storeId: mutation.id,
         version,
         changedPaths: mutation.changedPaths,
       });
+      await this.drainPendingWakes();
       return { status: "committed" };
     });
   }
@@ -216,6 +218,7 @@ export class MemoryStoreClient extends CasStoreClient {
       for (const [key, waiter] of [...this.waiters.entries()]) {
         if (waiter.storeName === name && waiter.storeId === params.id) {
           this.waiters.delete(key);
+          this.pendingWakes.delete(key);
         }
       }
     });
@@ -268,7 +271,10 @@ export class MemoryStoreClient extends CasStoreClient {
 
       this.stores.delete(key);
       for (const [waiterKey, waiter] of [...this.waiters.entries()]) {
-        if (waiter.instanceId === record.instanceId) this.waiters.delete(waiterKey);
+        if (waiter.instanceId === record.instanceId) {
+          this.waiters.delete(waiterKey);
+          this.pendingWakes.delete(waiterKey);
+        }
       }
       const result = { deleted: true as const };
       if (ledgerKey) this.appliedSteps.set(ledgerKey, JSON.stringify(result));
@@ -297,20 +303,21 @@ export class MemoryStoreClient extends CasStoreClient {
         record.version > waiter.sinceVersion
       ) {
         this.waiters.set(key, cloneStoreState(waiter));
-        await this.deliverWaiter(key, waiter);
+        this.pendingWakes.add(key);
+        await this.drainPendingWakes();
         return;
       }
       this.waiters.set(key, cloneStoreState(waiter));
     });
   }
 
-  private async wakeWaiters(params: {
+  private enqueueMatchingWakes(params: {
     storeName: string;
     storeId: string;
     version: number;
     changedPaths: readonly (readonly (string | number)[])[];
   }) {
-    for (const [key, waiter] of [...this.waiters.entries()]) {
+    for (const [key, waiter] of this.waiters) {
       if (waiter.storeName !== params.storeName) continue;
       if (waiter.storeId !== params.storeId) continue;
       if (waiter.sinceVersion >= params.version) continue;
@@ -318,18 +325,27 @@ export class MemoryStoreClient extends CasStoreClient {
         continue;
       }
 
-      await this.deliverWaiter(key, waiter);
+      this.pendingWakes.add(key);
     }
   }
 
-  private async deliverWaiter(key: string, waiter: StoreWaiter) {
-    try {
-      await this.schedulerClient.requestWakeUp(waiter.event);
-      this.waiters.delete(key);
-    } catch (error) {
-      // The waiter is the retryable wake intent for this non-durable store.
-      // Leave it registered so the next matching mutation retries delivery.
-      console.error("Failed to deliver pending store wake", error);
+  private async drainPendingWakes() {
+    for (const key of [...this.pendingWakes]) {
+      const waiter = this.waiters.get(key);
+      if (!waiter) {
+        this.pendingWakes.delete(key);
+        continue;
+      }
+
+      try {
+        await this.schedulerClient.requestWakeUp(waiter.event);
+        this.pendingWakes.delete(key);
+        this.waiters.delete(key);
+      } catch (error) {
+        // Keep both entries so every later committed mutation retries this
+        // delivery, regardless of which store paths that mutation changed.
+        console.error("Failed to deliver pending store wake", error);
+      }
     }
   }
 

--- a/packages/yieldstar/src/internal/step-runner.ts
+++ b/packages/yieldstar/src/internal/step-runner.ts
@@ -47,12 +47,12 @@ export type WorkflowStore<T> = {
   ): AsyncGenerator<StepResponse, R>;
   update(
     key: string,
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+    updater: (draft: Draft<T>) => void | T
   ): AsyncGenerator<StepResponse, StoreUpdateResult<T>>;
   updateFrom(
     key: string,
     snapshot: StoreSnapshot<T>,
-    updater: (draft: Draft<T>) => void | T | Promise<void | T>
+    updater: (draft: Draft<T>) => void | T
   ): AsyncGenerator<StepResponse, StoreUpdateFromResult<T>>;
   deleteFrom(
     key: string,


### PR DESCRIPTION
## Summary

- make store updater callbacks synchronous, deterministic CAS transformations
- add a shared `CasStoreClient` read/compute/conditional-commit protocol
- migrate the SQLite store runtime to atomically commit state, applied-step receipts, and durable wake intents
- retain path-selective waking while adding retry, startup recovery, and cross-client waiter race protection

## Why

The existing store API exposed versioned snapshots, but the SQLite implementation executed updater callbacks while holding a write transaction. That model could not map cleanly to native conditional-write backends such as DynamoDB, and a crash after committing state but before enqueueing a wake could leave a workflow asleep indefinitely.

This change moves application transformations outside connector transactions and gives storage connectors one concrete atomic mutation protocol. SQLite now records wake intent in an outbox alongside the store transition and applied-step receipt, allowing failed or interrupted delivery to resume safely.

## Impact

- store selectors must now be synchronous and side-effect-free because CAS conflicts may re-run them
- successful mutations preserve exactly-once workflow-step receipts
- wake delivery remains path-selective and becomes durable across retry and process restart
- existing `updateStoreFrom` receipt rows are normalized during replay for compatibility

## Validation

- `bun run bundle`
- `bun test` — 108 passed, 1 skipped, 0 failed
- `git diff --check`
- independent concurrency and recovery review, with all findings addressed
